### PR TITLE
Fix: setup.py's get_requirements designed for wrong file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,8 @@ def get_version():
 
 
 def get_requirements():
-    with open("requirements.in") as reqs:
-        return [
-            line.split()[0]
-            for line in reqs.read().splitlines()
-            if not line.startswith("#")
-        ]
+    with open("requirements.in") as f:
+        return f.read().splitlines()
 
 
 setup(


### PR DESCRIPTION
Commit 05d60a5842cbce953a477573ba95908a71ac437d introduced a function in
setup.py to derive install requirements from requirements.txt when it
should've been intended for requirements.in. This commit corrects the
mistake.

Signed-off-by: Nathan Gillett <ngillett@redhat.com>