### PR TITLE
Fix: package fails from missing manifest listing

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include VERSION
+include requirements.in


### PR DESCRIPTION
Build needs requirements.in file to derive install_requires but it
wasn't included by MANIFEST.in.

Signed-off-by: Nathan Gillett <ngillett@redhat.com>