### PR TITLE
Fix ValueError in requests.get()

### DIFF
--- a/src/physrisk/requests.py
+++ b/src/physrisk/requests.py
@@ -24,7 +24,7 @@ def get(*, request_id, request_dict):
         request = HazardEventAvailabilityRequest(**request_dict)
         return json.dumps(_get_hazard_data_availability(request).dict())
     else:
-        raise ValueError("request type " + request_dict["request_id"] + " not found")
+        raise ValueError(f"request type '{request_id}' not found")
 
 
 def _get_hazard_data_availability(request: HazardEventAvailabilityRequest):


### PR DESCRIPTION
Previously, the ValueError message expected request_dict["request_id"],
but request_id is now a parameter and is not expected to be included within
request_dict. This change modifies the ValueError message accordingly.