### PR TITLE
Avoid overriding an asset impact result if empty

### DIFF
--- a/src/physrisk/kernel/impact.py
+++ b/src/physrisk/kernel/impact.py
@@ -72,9 +72,13 @@ def calculate_impacts(  # noqa: C901
             hazard_data = [responses[req] for req in get_iterable(requests)]
             if any(isinstance(hd, HazardDataFailedResponse) for hd in hazard_data):
                 assert isinstance(model, VulnerabilityModelBase)
-                results[ImpactKey(asset=asset, hazard_type=model.hazard_type, scenario=scenario, key_year=year)] = (
-                    AssetImpactResult(EmptyImpactDistrib())
-                )
+                if (
+                    ImpactKey(asset=asset, hazard_type=model.hazard_type, scenario=scenario, key_year=year)
+                    not in results
+                ):
+                    results[ImpactKey(asset=asset, hazard_type=model.hazard_type, scenario=scenario, key_year=year)] = (
+                        AssetImpactResult(EmptyImpactDistrib())
+                    )
                 continue
             try:
                 if isinstance(model, VulnerabilityModelAcuteBase):
@@ -90,9 +94,13 @@ def calculate_impacts(  # noqa: C901
             except Exception as e:
                 logger.exception(e)
                 assert isinstance(model, VulnerabilityModelBase)
-                results[ImpactKey(asset=asset, hazard_type=model.hazard_type, scenario=scenario, key_year=year)] = (
-                    AssetImpactResult(EmptyImpactDistrib())
-                )
+                if (
+                    ImpactKey(asset=asset, hazard_type=model.hazard_type, scenario=scenario, key_year=year)
+                    not in results
+                ):
+                    results[ImpactKey(asset=asset, hazard_type=model.hazard_type, scenario=scenario, key_year=year)] = (
+                        AssetImpactResult(EmptyImpactDistrib())
+                    )
     return results
 
 

--- a/tests/models/power_generating_asset_models_test.py
+++ b/tests/models/power_generating_asset_models_test.py
@@ -154,9 +154,9 @@ class TestPowerGeneratingAssetModels(TestWithCredentials):
         out = [
             {
                 "asset": type(result.asset).__name__,
-                "type": getattr(result.asset, "type"),
-                "capacity": getattr(result.asset, "capacity"),
-                "location": getattr(result.asset, "location"),
+                "type": getattr(result.asset, "type", None),
+                "capacity": getattr(result.asset, "capacity", None),
+                "location": getattr(result.asset, "location", None),
                 "latitude": result.asset.latitude,
                 "longitude": result.asset.longitude,
                 "impact_mean": (
@@ -175,8 +175,8 @@ class TestPowerGeneratingAssetModels(TestWithCredentials):
         items = [
             physrisk.api.v1.common.Asset(
                 asset_class=type(a).__name__,
-                type=getattr(a, "type"),
-                location=getattr(a, "location"),
+                type=getattr(a, "type", None),
+                location=getattr(a, "location", None),
                 latitude=a.latitude,
                 longitude=a.longitude,
             )


### PR DESCRIPTION
Avoid overriding an asset impact result if empty