### PR TITLE
Retrieve path to the hazard event data source

### DIFF
--- a/src/physrisk/api/v1/common.py
+++ b/src/physrisk/api/v1/common.py
@@ -121,6 +121,7 @@ class HazardEventDistrib(BaseModel):
 
     intensity_bin_edges: np.ndarray = Field(default_factory=lambda: np.zeros(10), description="")
     probabilities: np.ndarray = Field(default_factory=lambda: np.zeros(10), description="")
+    path: Optional[str] = Field(None, description="Path to the hazard event data source.")
 
     class Config:
         arbitrary_types_allowed = True

--- a/src/physrisk/api/v1/exposure_req_resp.py
+++ b/src/physrisk/api/v1/exposure_req_resp.py
@@ -29,6 +29,7 @@ class AssetExposureRequest(BaseModel):
 class Exposure(BaseModel):
     category: str
     value: Optional[float]
+    path: Optional[str] = Field(None, description="""Path to the hazard event data source.""")
 
 
 class AssetExposure(BaseModel):

--- a/src/physrisk/api/v1/impact_req_resp.py
+++ b/src/physrisk/api/v1/impact_req_resp.py
@@ -123,6 +123,7 @@ class AcuteHazardCalculationDetails(BaseModel):
     hazard_exceedance: ExceedanceCurve
     hazard_distribution: Distribution
     vulnerability_distribution: VulnerabilityDistrib
+    hazard_path: Optional[str] = Field(None, description="Path to the hazard event data source.")
 
 
 class ImpactKey(BaseModel):

--- a/src/physrisk/data/hazard_data_provider.py
+++ b/src/physrisk/data/hazard_data_provider.py
@@ -93,6 +93,7 @@ class AcuteHazardDataProvider(HazardDataProvider):
         Returns:
             curves: numpy array of intensity (no. coordinate pairs, no. return periods).
             return_periods: return periods in years.
+            path: path to the hazard event data source.
         """
 
         path = self._get_source_path(indicator_id=indicator_id, scenario=scenario, year=year, hint=hint)
@@ -117,7 +118,7 @@ class AcuteHazardDataProvider(HazardDataProvider):
                 ],
                 self._interpolation,
             )  # type: ignore
-        return curves, return_periods
+        return curves, return_periods, path
 
 
 class ChronicHazardDataProvider(HazardDataProvider):
@@ -153,9 +154,10 @@ class ChronicHazardDataProvider(HazardDataProvider):
             year: projection year, e.g. 2080.
 
         Returns:
-            parameters: numpy array of parameters
+            parameters: numpy array of parameters.
+            path: path to the hazard event data source.
         """
 
         path = self._get_source_path(indicator_id=indicator_id, scenario=scenario, year=year, hint=hint)
         parameters, defns = self._reader.get_curves(path, longitudes, latitudes, self._interpolation)
-        return parameters, defns
+        return parameters, defns, path

--- a/src/physrisk/data/pregenerated_hazard_model.py
+++ b/src/physrisk/data/pregenerated_hazard_model.py
@@ -84,7 +84,7 @@ class PregeneratedHazardModel(HazardModel):
             longitudes = [req.longitude for req in batch]
             latitudes = [req.latitude for req in batch]
             if hazard_type.kind == HazardKind.acute:  # type: ignore
-                intensities, return_periods = self.acute_hazard_data_providers[hazard_type].get_intensity_curves(
+                intensities, return_periods, path = self.acute_hazard_data_providers[hazard_type].get_intensity_curves(
                     longitudes,
                     latitudes,
                     indicator_id=indicator_id,
@@ -99,15 +99,15 @@ class PregeneratedHazardModel(HazardModel):
                     valid_periods, valid_intensities = return_periods[valid], intensities[i, :][valid]
                     if len(valid_periods) == 0:
                         valid_periods, valid_intensities = np.array([100]), np.array([0])
-                    responses[req] = HazardEventDataResponse(valid_periods, valid_intensities)
+                    responses[req] = HazardEventDataResponse(valid_periods, valid_intensities, path)
             elif hazard_type.kind == HazardKind.chronic:  # type: ignore
-                parameters, defns = self.chronic_hazard_data_providers[hazard_type].get_parameters(
+                parameters, defns, path = self.chronic_hazard_data_providers[hazard_type].get_parameters(
                     longitudes, latitudes, indicator_id=indicator_id, scenario=scenario, year=year, hint=hint
                 )
 
                 for i, req in enumerate(batch):
                     valid = ~np.isnan(parameters[i, :])
-                    responses[req] = HazardParameterDataResponse(parameters[i, :][valid], defns[valid])
+                    responses[req] = HazardParameterDataResponse(parameters[i, :][valid], defns[valid], path)
         except Exception as err:
             # e.g. the requested data is unavailable
             for i, req in enumerate(batch):

--- a/src/physrisk/kernel/exposure.py
+++ b/src/physrisk/kernel/exposure.py
@@ -72,7 +72,7 @@ class JupterExposureMeasure(ExposureMeasure):
         ]
 
     def get_exposures(self, asset: Asset, data_responses: Iterable[HazardDataResponse]):
-        result: Dict[type, Tuple[Category, float]] = {}
+        result: Dict[type, Tuple[Category, float, str]] = {}
         for (k, v), resp in zip(self.exposure_bins.items(), data_responses):
             if isinstance(resp, HazardParameterDataResponse):
                 param = resp.parameter
@@ -86,7 +86,7 @@ class JupterExposureMeasure(ExposureMeasure):
                 result[hazard_type] = (Category.NODATA, float(param))
             else:
                 index = np.searchsorted(lower_bounds, param, side="right") - 1
-                result[hazard_type] = (categories[index], float(param))
+                result[hazard_type] = (categories[index], float(param), resp.path)
         return result
 
     def get_exposure_bins(self):

--- a/src/physrisk/kernel/hazard_event_distrib.py
+++ b/src/physrisk/kernel/hazard_event_distrib.py
@@ -13,7 +13,7 @@ class HazardEventDistrib:
 
     def __init__(
         self, event_type: type, intensity_bins: Union[List[float], np.ndarray], prob: Union[List[float], np.ndarray],
-        path: str = None
+        path: List[str] = None
     ):
         """Create a new asset event distribution.
         Args:
@@ -43,5 +43,5 @@ class HazardEventDistrib:
         return self.__prob
 
     @property
-    def path(self) -> str:
+    def path(self) -> List[str]:
         return self.__path

--- a/src/physrisk/kernel/hazard_event_distrib.py
+++ b/src/physrisk/kernel/hazard_event_distrib.py
@@ -9,21 +9,24 @@ class HazardEventDistrib:
     """Intensity distribution of a hazard event (e.g. inundation depth, wind speed etc),
     specific to an asset -- that is, at the location of the asset."""
 
-    __slots__ = ["__event_type", "__intensity_bins", "__prob", "__exceedance"]
+    __slots__ = ["__event_type", "__intensity_bins", "__prob", "__path", "__exceedance"]
 
     def __init__(
-        self, event_type: type, intensity_bins: Union[List[float], np.ndarray], prob: Union[List[float], np.ndarray]
+        self, event_type: type, intensity_bins: Union[List[float], np.ndarray], prob: Union[List[float], np.ndarray],
+        path: str = None
     ):
         """Create a new asset event distribution.
         Args:
             event_type: type of event
             intensity_bins: non-decreasing intensity bin edges.
             e.g. bin edges [1.0, 1.5, 2.0] imply two bins: 1.0 < i <= 1.5, 1.5 < i <= 2.0
-            prob: (annual) probability of occurrence for each intensity bin with size [len(intensity_bins) - 1]
+            prob: (annual) probability of occurrence for each intensity bin with size [len(intensity_bins) - 1].
+            path: path to the hazard event data source.
         """
         self.__event_type = event_type
         self.__intensity_bins = np.array(intensity_bins)
         self.__prob = np.array(prob)
+        self.__path = path
 
     def intensity_bins(self):
         return zip(self.__intensity_bins[0:-1], self.__intensity_bins[1:])
@@ -38,3 +41,7 @@ class HazardEventDistrib:
     @property
     def prob(self) -> np.ndarray:
         return self.__prob
+
+    @property
+    def path(self) -> str:
+        return self.__path

--- a/src/physrisk/kernel/hazard_model.py
+++ b/src/physrisk/kernel/hazard_model.py
@@ -82,7 +82,7 @@ class HazardEventDataResponse(HazardDataResponse):
 
         self.return_periods = return_periods
         self.intensities = intensities
-        self.path = sys.intern(path)
+        self.path = sys.intern(path) if path is not None else None
 
 
 class HazardParameterDataResponse(HazardDataResponse):
@@ -103,7 +103,7 @@ class HazardParameterDataResponse(HazardDataResponse):
         """
         self.parameters = parameters
         self.param_defns = param_defns
-        self.path = sys.intern(path)
+        self.path = sys.intern(path) if path is not None else None
 
     @property
     def parameter(self) -> float:

--- a/src/physrisk/kernel/hazard_model.py
+++ b/src/physrisk/kernel/hazard_model.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from typing import Dict, List, Mapping, Optional, Protocol, Tuple
 
 import numpy as np
+import sys
 
 from physrisk.data.hazard_data_provider import HazardDataHint
 
@@ -70,22 +71,24 @@ class HazardDataFailedResponse(HazardDataResponse):
 class HazardEventDataResponse(HazardDataResponse):
     """Response to HazardDataRequest for acute hazards."""
 
-    def __init__(self, return_periods: np.ndarray, intensities: np.ndarray):
+    def __init__(self, return_periods: np.ndarray, intensities: np.ndarray, path: Optional[str] = None):
         """Create HazardEventDataResponse.
 
         Args:
             return_periods: return periods in years.
             intensities: hazard event intensity for each return period, or set of hazard event intensities corresponding to different events. # noqa: E501
+            path: path to the hazard event data source.
         """
 
         self.return_periods = return_periods
         self.intensities = intensities
+        self.path = sys.intern(path)
 
 
 class HazardParameterDataResponse(HazardDataResponse):
     """Response to HazardDataRequest."""
 
-    def __init__(self, parameters: np.ndarray, param_defns: np.ndarray = np.empty([])):
+    def __init__(self, parameters: np.ndarray, param_defns: np.ndarray = np.empty([]), path: Optional[str] = None):
         """Create HazardParameterDataResponse. In general the chronic parameters are an array of values.
         For example, a chronic hazard may be the number of days per year with average temperature
         above :math:`x' degrees for :math:`x' in [25, 30, 35, 40]°C. In this case the param_defns would
@@ -96,9 +99,11 @@ class HazardParameterDataResponse(HazardDataResponse):
         Args:
             parameters (np.ndarray): Chronic hazard parameter values.
             param_defns (np.ndarray): Chronic hazard parameter definitions.
+            path: path to the hazard event data source.
         """
         self.parameters = parameters
         self.param_defns = param_defns
+        self.path = sys.intern(path)
 
     @property
     def parameter(self) -> float:

--- a/src/physrisk/kernel/impact_distrib.py
+++ b/src/physrisk/kernel/impact_distrib.py
@@ -14,7 +14,7 @@ class ImpactType(Enum):
 class ImpactDistrib:
     """Impact distributions specific to an asset."""
 
-    __slots__ = ["__hazard_type", "__impact_bins", "__prob", "impact_type"]
+    __slots__ = ["__hazard_type", "__impact_bins", "__prob", "impact_type", "__path"]
 
     def __init__(
         self,
@@ -22,17 +22,20 @@ class ImpactDistrib:
         impact_bins: Union[List[float], np.ndarray],
         prob: Union[List[float], np.ndarray],
         impact_type: ImpactType = ImpactType.damage,
+        path: str = None
     ):
         """Create a new asset event distribution.
         Args:
             event_type: type of event
             impact_bins: non-decreasing impact bin bounds
             prob: probabilities with size [len(intensity_bins) - 1]
+            path: path to the hazard event data source
         """
         self.__hazard_type = hazard_type
         self.__impact_bins = np.array(impact_bins)
         self.impact_type = impact_type
         self.__prob = np.array(prob)
+        self.__path = path
 
     def impact_bins_explicit(self):
         return zip(self.__impact_bins[0:-1], self.__impact_bins[1:])
@@ -59,6 +62,10 @@ class ImpactDistrib:
     @property
     def prob(self) -> np.ndarray:
         return self.__prob
+
+    @property
+    def path(self) -> str:
+        return self.__path
 
 
 class EmptyImpactDistrib(ImpactDistrib):

--- a/src/physrisk/kernel/impact_distrib.py
+++ b/src/physrisk/kernel/impact_distrib.py
@@ -22,7 +22,7 @@ class ImpactDistrib:
         impact_bins: Union[List[float], np.ndarray],
         prob: Union[List[float], np.ndarray],
         impact_type: ImpactType = ImpactType.damage,
-        path: str = None
+        path: List[str] = None
     ):
         """Create a new asset event distribution.
         Args:
@@ -64,7 +64,7 @@ class ImpactDistrib:
         return self.__prob
 
     @property
-    def path(self) -> str:
+    def path(self) -> List[str]:
         return self.__path
 
 

--- a/src/physrisk/kernel/vulnerability_model.py
+++ b/src/physrisk/kernel/vulnerability_model.py
@@ -1,7 +1,7 @@
 import importlib.resources
 import json
 from abc import ABC, abstractmethod
-from typing import Dict, Iterable, List, Optional, Protocol, Sequence, Tuple, Type, Union
+from typing import Dict, Iterable, List, Optional, Protocol, Sequence, Tuple, Type, Union, cast
 
 import numpy as np
 from scipy import stats
@@ -217,6 +217,8 @@ class VulnerabilityModel(VulnerabilityModelAcuteBase):
         (event_data,) = event_data_responses
         assert isinstance(event_data, HazardEventDataResponse)
 
+        hazard_paths = [cast(HazardEventDataResponse, r).path for r in event_data_responses]
+
         intensity_curve = ExceedanceCurve(1.0 / event_data.return_periods, event_data.intensities)
         intensity_bin_edges, probs = intensity_curve.get_probability_bins()
 
@@ -229,7 +231,7 @@ class VulnerabilityModel(VulnerabilityModelAcuteBase):
             self.get_impact_curve(intensity_bin_centres, asset).to_prob_matrix(self.impact_bin_edges),
         )
 
-        event = HazardEventDistrib(self.hazard_type, intensity_bin_edges, probs, event_data.path)
+        event = HazardEventDistrib(self.hazard_type, intensity_bin_edges, probs, hazard_paths)
         return vul, event
 
     @abstractmethod
@@ -303,6 +305,8 @@ class DeterministicVulnerabilityModel(VulnerabilityModelAcuteBase):
         (event_data,) = event_data_responses
         assert isinstance(event_data, HazardEventDataResponse)
 
+        hazard_paths = [cast(HazardEventDataResponse, r).path for r in event_data_responses]
+
         intensity_curve = ExceedanceCurve(1.0 / event_data.return_periods, event_data.intensities)
         intensity_bin_edges, probs = intensity_curve.get_probability_bins()
 
@@ -315,5 +319,5 @@ class DeterministicVulnerabilityModel(VulnerabilityModelAcuteBase):
         vul = VulnerabilityDistrib(
             type(self.hazard_type), intensity_bin_edges, impact_bins_edges, np.eye(len(impact_bins_edges) - 1)
         )
-        event = HazardEventDistrib(type(self.hazard_type), intensity_bin_edges, probs, event_data.path)
+        event = HazardEventDistrib(type(self.hazard_type), intensity_bin_edges, probs, hazard_paths)
         return vul, event

--- a/src/physrisk/kernel/vulnerability_model.py
+++ b/src/physrisk/kernel/vulnerability_model.py
@@ -166,7 +166,11 @@ class VulnerabilityModelAcuteBase(VulnerabilityModelBase):
         impact_prob = vulnerability_dist.prob_matrix.T @ event_dist.prob
         return (
             ImpactDistrib(
-                vulnerability_dist.event_type, vulnerability_dist.impact_bins, impact_prob, impact_type=self.impact_type
+                vulnerability_dist.event_type,
+                vulnerability_dist.impact_bins,
+                impact_prob,
+                impact_type=self.impact_type,
+                path=event_dist.path
             ),
             vulnerability_dist,
             event_dist,
@@ -225,7 +229,7 @@ class VulnerabilityModel(VulnerabilityModelAcuteBase):
             self.get_impact_curve(intensity_bin_centres, asset).to_prob_matrix(self.impact_bin_edges),
         )
 
-        event = HazardEventDistrib(self.hazard_type, intensity_bin_edges, probs)
+        event = HazardEventDistrib(self.hazard_type, intensity_bin_edges, probs, event_data.path)
         return vul, event
 
     @abstractmethod
@@ -311,5 +315,5 @@ class DeterministicVulnerabilityModel(VulnerabilityModelAcuteBase):
         vul = VulnerabilityDistrib(
             type(self.hazard_type), intensity_bin_edges, impact_bins_edges, np.eye(len(impact_bins_edges) - 1)
         )
-        event = HazardEventDistrib(type(self.hazard_type), intensity_bin_edges, probs)
+        event = HazardEventDistrib(type(self.hazard_type), intensity_bin_edges, probs, event_data.path)
         return vul, event

--- a/src/physrisk/requests.py
+++ b/src/physrisk/requests.py
@@ -316,7 +316,7 @@ def _get_asset_exposures(
             AssetExposure(
                 asset_id="",
                 exposures=dict(
-                    (t.__name__, Exposure(category=c.name, value=v)) for (t, (c, v)) in r.hazard_categories.items()
+                    (t.__name__, Exposure(category=c.name, value=v, path=p)) for (t, (c, v, p)) in r.hazard_categories.items()
                 ),
             )
             for (a, r) in results.items()
@@ -374,6 +374,7 @@ def _get_asset_impacts(
                             bin_edges=v.event.intensity_bin_edges, probabilities=v.event.prob
                         ),
                         vulnerability_distribution=vulnerability_distribution,
+                        hazard_path=v.impact.path
                     )
             else:
                 calc_details = None

--- a/src/physrisk/vulnerability_models/chronic_heat_models.py
+++ b/src/physrisk/vulnerability_models/chronic_heat_models.py
@@ -75,6 +75,8 @@ class ChronicHeatGZNModel(VulnerabilityModelBase):
         assert isinstance(baseline_dd_above_mean, HazardParameterDataResponse)
         assert isinstance(scenario_dd_above_mean, HazardParameterDataResponse)
 
+        hazard_paths = [cast(HazardParameterDataResponse, r).path for r in data_responses]
+
         delta_dd_above_mean: float = scenario_dd_above_mean.parameter - baseline_dd_above_mean.parameter * self.delta
 
         hours_worked = self.total_labour_hours
@@ -82,7 +84,7 @@ class ChronicHeatGZNModel(VulnerabilityModelBase):
         fraction_loss_std = (delta_dd_above_mean * self.time_lost_per_degree_day_se) / hours_worked
 
         return get_impact_distrib(fraction_loss_mean, fraction_loss_std, ChronicHeat, ImpactType.disruption,
-                                  scenario_dd_above_mean.path)
+                                  hazard_paths)
 
 
 class ChronicHeatWBGTGZNModel(ChronicHeatGZNModel):
@@ -169,6 +171,8 @@ class ChronicHeatWBGTGZNModel(ChronicHeatGZNModel):
         assert isinstance(asset, IndustrialActivity)
         wbgt_responses = [cast(HazardParameterDataResponse, r) for r in data_responses[2:]]
 
+        hazard_paths = [cast(HazardParameterDataResponse, r).path for r in data_responses]
+
         baseline_dd_above_mean = cast(HazardParameterDataResponse, data_responses[0])
         scenario_dd_above_mean = cast(HazardParameterDataResponse, data_responses[1])
 
@@ -233,7 +237,7 @@ class ChronicHeatWBGTGZNModel(ChronicHeatGZNModel):
 
         total_work_loss_delta: float = baseline_work_ability - scenario_work_ability
 
-        return get_impact_distrib(total_work_loss_delta, std_delta, self.hazard_type, self.impact_type)
+        return get_impact_distrib(total_work_loss_delta, std_delta, self.hazard_type, self.impact_type, hazard_paths)
 
 
 def two_variable_joint_variance(ex, varx, ey, vary):
@@ -244,7 +248,8 @@ def two_variable_joint_variance(ex, varx, ey, vary):
 
 
 def get_impact_distrib(
-    fraction_loss_mean: float, fraction_loss_std: float, hazard_type: type, impact_type: ImpactType, path: str = None
+    fraction_loss_mean: float, fraction_loss_std: float, hazard_type: type, impact_type: ImpactType,
+    hazard_paths: List[str] = None
 ) -> ImpactDistrib:
     """Calculate impact (disruption) of asset based on the hazard data returned.
 
@@ -253,7 +258,7 @@ def get_impact_distrib(
         fraction_loss_std: standard deviation of the impact distribution
         hazard_type: Hazard Type.
         impact_type: Impact Type.
-        path: path to the hazard event data source.
+        hazard_paths: path to the hazard event data source.
 
     Returns:
         Probability distribution of impacts.
@@ -284,4 +289,4 @@ def get_impact_distrib(
     else:
         probs[0] = probs[0] + prob_differential
 
-    return ImpactDistrib(hazard_type, impact_bins, probs, impact_type, path)
+    return ImpactDistrib(hazard_type, impact_bins, probs, impact_type, hazard_paths)

--- a/src/physrisk/vulnerability_models/chronic_heat_models.py
+++ b/src/physrisk/vulnerability_models/chronic_heat_models.py
@@ -81,7 +81,8 @@ class ChronicHeatGZNModel(VulnerabilityModelBase):
         fraction_loss_mean = (delta_dd_above_mean * self.time_lost_per_degree_day) / hours_worked
         fraction_loss_std = (delta_dd_above_mean * self.time_lost_per_degree_day_se) / hours_worked
 
-        return get_impact_distrib(fraction_loss_mean, fraction_loss_std, ChronicHeat, ImpactType.disruption)
+        return get_impact_distrib(fraction_loss_mean, fraction_loss_std, ChronicHeat, ImpactType.disruption,
+                                  scenario_dd_above_mean.path)
 
 
 class ChronicHeatWBGTGZNModel(ChronicHeatGZNModel):
@@ -243,7 +244,7 @@ def two_variable_joint_variance(ex, varx, ey, vary):
 
 
 def get_impact_distrib(
-    fraction_loss_mean: float, fraction_loss_std: float, hazard_type: type, impact_type: ImpactType
+    fraction_loss_mean: float, fraction_loss_std: float, hazard_type: type, impact_type: ImpactType, path: str = None
 ) -> ImpactDistrib:
     """Calculate impact (disruption) of asset based on the hazard data returned.
 
@@ -252,6 +253,7 @@ def get_impact_distrib(
         fraction_loss_std: standard deviation of the impact distribution
         hazard_type: Hazard Type.
         impact_type: Impact Type.
+        path: path to the hazard event data source.
 
     Returns:
         Probability distribution of impacts.
@@ -282,4 +284,4 @@ def get_impact_distrib(
     else:
         probs[0] = probs[0] + prob_differential
 
-    return ImpactDistrib(hazard_type, impact_bins, probs, impact_type)
+    return ImpactDistrib(hazard_type, impact_bins, probs, impact_type, path)

--- a/src/physrisk/vulnerability_models/power_generating_asset_models.py
+++ b/src/physrisk/vulnerability_models/power_generating_asset_models.py
@@ -74,7 +74,7 @@ class InundationModel(VulnerabilityModelAcuteBase):
         probs_protected = np.where(depth_bins[1:] <= protection_depth, 0.0, 1.0)
 
         vul = VulnerabilityDistrib(RiverineInundation, depth_bins, impact_bins, np.diag(probs_protected))
-        event = HazardEventDistrib(RiverineInundation, depth_bins, probs)
+        event = HazardEventDistrib(RiverineInundation, depth_bins, probs, histo.path)
 
         return vul, event
 

--- a/src/physrisk/vulnerability_models/power_generating_asset_models.py
+++ b/src/physrisk/vulnerability_models/power_generating_asset_models.py
@@ -74,7 +74,7 @@ class InundationModel(VulnerabilityModelAcuteBase):
         probs_protected = np.where(depth_bins[1:] <= protection_depth, 0.0, 1.0)
 
         vul = VulnerabilityDistrib(RiverineInundation, depth_bins, impact_bins, np.diag(probs_protected))
-        event = HazardEventDistrib(RiverineInundation, depth_bins, probs, histo.path)
+        event = HazardEventDistrib(RiverineInundation, depth_bins, probs, [future.path])
 
         return vul, event
 

--- a/src/physrisk/vulnerability_models/real_estate_models.py
+++ b/src/physrisk/vulnerability_models/real_estate_models.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, cast
 
 import numpy as np
 
@@ -227,9 +227,10 @@ class CoolingModel(VulnerabilityModelBase):
     def get_impact(self, asset: Asset, data_responses: List[HazardDataResponse]) -> ImpactDistrib:
         (data,) = data_responses
         assert isinstance(data, HazardParameterDataResponse)
+        hazard_paths = [cast(HazardParameterDataResponse, r).path for r in data_responses]
         # we interpolate the specific threshold from the different values
         deg_days = float(np.interp(self.threshold_temp_c, data.param_defns, data.parameters))  # [0]
         heat_transfer = deg_days * self._default_transfer_coeff * 24 / 1000  # kWh of heat removed from asset
         annual_electricity = heat_transfer / self._default_cooling_cop  # kWh of electricity required for heat removal
         # this is non-probabilistic model: probability of 1 of electricity use
-        return ImpactDistrib(ChronicHeat, [annual_electricity, annual_electricity], [1], path=data.path)
+        return ImpactDistrib(ChronicHeat, [annual_electricity, annual_electricity], [1], path=hazard_paths)

--- a/src/physrisk/vulnerability_models/real_estate_models.py
+++ b/src/physrisk/vulnerability_models/real_estate_models.py
@@ -232,4 +232,4 @@ class CoolingModel(VulnerabilityModelBase):
         heat_transfer = deg_days * self._default_transfer_coeff * 24 / 1000  # kWh of heat removed from asset
         annual_electricity = heat_transfer / self._default_cooling_cop  # kWh of electricity required for heat removal
         # this is non-probabilistic model: probability of 1 of electricity use
-        return ImpactDistrib(ChronicHeat, [annual_electricity, annual_electricity], [1])
+        return ImpactDistrib(ChronicHeat, [annual_electricity, annual_electricity], [1], path=data.path)

--- a/src/physrisk/vulnerability_models/thermal_power_generation_models.py
+++ b/src/physrisk/vulnerability_models/thermal_power_generation_models.py
@@ -113,6 +113,8 @@ class ThermalPowerGenerationInundationModel(DeterministicVulnerabilityModel):
         assert isinstance(response_scenario, HazardEventDataResponse)
         assert isinstance(response_baseline, HazardEventDataResponse)
 
+        hazard_paths = [cast(HazardEventDataResponse, r).path for r in event_data_responses]
+
         baseline_curve = ExceedanceCurve(1.0 / response_baseline.return_periods, response_baseline.intensities)
         protection_depth = (
             0.0
@@ -151,7 +153,7 @@ class ThermalPowerGenerationInundationModel(DeterministicVulnerabilityModel):
             impact_bins = [0.0 for _ in intensity_bins]
 
         vul = VulnerabilityDistrib(self.hazard_type, intensity_bins, impact_bins, np.eye(len(probability_bins)))
-        event = HazardEventDistrib(self.hazard_type, intensity_bins, probability_bins, response_scenario.path)
+        event = HazardEventDistrib(self.hazard_type, intensity_bins, probability_bins, hazard_paths)
         return vul, event
 
 
@@ -244,6 +246,8 @@ class ThermalPowerGenerationDroughtModel(VulnerabilityModelBase):
     def get_impact(self, asset: Asset, data_responses: List[HazardDataResponse]) -> ImpactDistrib:
         assert isinstance(asset, ThermalPowerGeneratingAsset)
 
+        hazard_paths = [cast(HazardParameterDataResponse, r).path for r in data_responses]
+
         # The unit being number of months per year, we divide by 12 to express the result as a year fraction.
         (data,) = data_responses
         intensities = np.array(cast(HazardParameterDataResponse, data_responses[0]).parameters / 12.0)
@@ -300,7 +304,7 @@ class ThermalPowerGenerationDroughtModel(VulnerabilityModelBase):
             impact_bins,
             probability_bins,
             self.impact_type,
-            data.path
+            hazard_paths
         )
         return impact_distrib
 
@@ -374,6 +378,8 @@ class ThermalPowerGenerationAirTemperatureModel(VulnerabilityModelBase):
 
         assert 2 * len(self.temperatures) == len(data_responses)
 
+        hazard_paths = [cast(HazardParameterDataResponse, r).path for r in data_responses]
+
         # The unit being number of days per year, we divide by 365 to express the result as a year fraction.
         baseline = [
             1.0 - cast(HazardParameterDataResponse, data_response).parameter / 365.0
@@ -435,6 +441,7 @@ class ThermalPowerGenerationAirTemperatureModel(VulnerabilityModelBase):
             impact_bins,
             probability_bins,
             self.impact_type,
+            hazard_paths
         )
         return impact_distrib
 
@@ -532,6 +539,8 @@ class ThermalPowerGenerationWaterTemperatureModel(VulnerabilityModelBase):
     def get_impact(self, asset: Asset, data_responses: List[HazardDataResponse]) -> ImpactDistrib:
         assert isinstance(asset, ThermalPowerGeneratingAsset)
         assert len(data_responses) == 4
+
+        hazard_paths = [cast(HazardParameterDataResponse, r).path for r in data_responses]
 
         # Water temperature below which the power plant does not experience generation losses.
         design_intake_water_temperature = cast(
@@ -673,6 +682,7 @@ class ThermalPowerGenerationWaterTemperatureModel(VulnerabilityModelBase):
                     impact_bins,
                     probability_bins,
                     self.impact_type,
+                    hazard_paths
                 )
             )
 
@@ -684,6 +694,7 @@ class ThermalPowerGenerationWaterTemperatureModel(VulnerabilityModelBase):
                 [0.0 for _ in range(0, len(intake_water_temperature_probability_bins) + 1)],
                 intake_water_temperature_probability_bins,
                 self.impact_type,
+                hazard_paths
             )
 
         return impact_distrib
@@ -761,6 +772,8 @@ class ThermalPowerGenerationWaterStressModel(VulnerabilityModelBase):
         assert isinstance(asset, ThermalPowerGeneratingAsset)
         assert len(data_responses) == 3
 
+        hazard_paths = [cast(HazardParameterDataResponse, r).path for r in data_responses]
+
         if (
             len(cast(HazardParameterDataResponse, data_responses[0]).parameters) == 0
             or len(cast(HazardParameterDataResponse, data_responses[1]).parameters) == 0
@@ -801,5 +814,6 @@ class ThermalPowerGenerationWaterStressModel(VulnerabilityModelBase):
             [impact, impact],
             [probability_water_stress_above_40pct],
             self.impact_type,
+            hazard_paths
         )
         return impact_distrib

--- a/src/physrisk/vulnerability_models/thermal_power_generation_models.py
+++ b/src/physrisk/vulnerability_models/thermal_power_generation_models.py
@@ -151,7 +151,7 @@ class ThermalPowerGenerationInundationModel(DeterministicVulnerabilityModel):
             impact_bins = [0.0 for _ in intensity_bins]
 
         vul = VulnerabilityDistrib(self.hazard_type, intensity_bins, impact_bins, np.eye(len(probability_bins)))
-        event = HazardEventDistrib(self.hazard_type, intensity_bins, probability_bins)
+        event = HazardEventDistrib(self.hazard_type, intensity_bins, probability_bins, response_scenario.path)
         return vul, event
 
 
@@ -245,6 +245,7 @@ class ThermalPowerGenerationDroughtModel(VulnerabilityModelBase):
         assert isinstance(asset, ThermalPowerGeneratingAsset)
 
         # The unit being number of months per year, we divide by 12 to express the result as a year fraction.
+        (data,) = data_responses
         intensities = np.array(cast(HazardParameterDataResponse, data_responses[0]).parameters / 12.0)
         if len(intensities) == 1:
             thresholds = np.array([-2.0])  # hard-coded
@@ -299,6 +300,7 @@ class ThermalPowerGenerationDroughtModel(VulnerabilityModelBase):
             impact_bins,
             probability_bins,
             self.impact_type,
+            data.path
         )
         return impact_distrib
 


### PR DESCRIPTION
The purpose of these changes is to retrieve the path of the hazards event data source so that it can be used to extract the correct descriptions and information from the inventory and display them in the UI. The path depends on the year, the scenario and the model.
These improvements aim to enhance the accuracy and relevance of the hazard information presented in the UI.