### PR TITLE
Change WRI Inundation hazard selectors behaviour.

### DIFF
--- a/src/physrisk/hazard_models/core_hazards.py
+++ b/src/physrisk/hazard_models/core_hazards.py
@@ -142,12 +142,10 @@ class InventorySourcePaths:
                 if scenarios is None:
                     scenarios = next(
                         s
-                        for s in sorted(
-                            resource.scenarios, key=lambda s: next(y for y in s.years)
-                        )
+                        for s in sorted(resource.scenarios, key=lambda s: min(s.years))
                     )
                 proxy_scenario = scenarios.id
-                year = next(s for s in scenarios.years)
+                year = min(scenarios.years)
             return resource.path.format(
                 id=indicator_id, scenario=proxy_scenario, year=year
             )
@@ -216,11 +214,7 @@ class CoreInventorySourcePaths(InventorySourcePaths):
         year: int,
         hint: Optional[HazardDataHint] = None,
     ):
-        return (
-            candidates.with_model_id("nosub").first()
-            if scenario == "historical"
-            else candidates.with_model_id("wtsub/95").first()
-        )
+        return candidates.with_model_id("wtsub/95").first()
 
     @staticmethod
     def _select_riverine_inundation(
@@ -229,11 +223,7 @@ class CoreInventorySourcePaths(InventorySourcePaths):
         year: int,
         hint: Optional[HazardDataHint] = None,
     ):
-        return (
-            candidates.with_model_gcm("historical").first()
-            if scenario == "historical"
-            else candidates.with_model_gcm("MIROC-ESM-CHEM").first()
-        )
+        return candidates.with_model_gcm("MIROC-ESM-CHEM").first()
 
     @staticmethod
     def _select_riverine_inundation_tudelft(

--- a/src/physrisk/vulnerability_models/thermal_power_generation_models.py
+++ b/src/physrisk/vulnerability_models/thermal_power_generation_models.py
@@ -116,8 +116,8 @@ class ThermalPowerGenerationInundationModel(DeterministicVulnerabilityModel):
             self.hazard_type,
             asset.longitude,
             asset.latitude,
-            scenario=scenario,
-            year=2030,
+            scenario="historical",
+            year=-1,
             indicator_id=self.indicator_id,
             buffer=self.buffer,
         )

--- a/tests/api/data_requests_test.py
+++ b/tests/api/data_requests_test.py
@@ -73,7 +73,7 @@ class TestDataRequests(TestWithCredentials):
         assert result_flood == "inundation/wri/v2/inunriver_rcp8p5_MIROC-ESM-CHEM_2050"
         assert (
             result_flood_hist
-            == "inundation/wri/v2/inunriver_historical_000000000WATCH_1980"
+            == "inundation/wri/v2/inunriver_rcp4p5_MIROC-ESM-CHEM_2030"
         )
         assert (
             result_heat_hint

--- a/tests/api/impact_requests_test.py
+++ b/tests/api/impact_requests_test.py
@@ -267,7 +267,7 @@ class TestImpactRequests(TestWithCredentials):
             root,
             longitudes,
             latitudes,
-            "inundation/wri/v2/inunriver_rcp8p5_MIROC-ESM-CHEM_2030",
+            "inundation/wri/v2/inunriver_rcp4p5_MIROC-ESM-CHEM_2030",
             shape,
             np.array(
                 [

--- a/tests/data/hazard_model_store_test.py
+++ b/tests/data/hazard_model_store_test.py
@@ -370,8 +370,8 @@ def wbgt_gzn_joint_parameter_set():
 def inundation_paths():
     paths = []
     for model, scenario, year in [
+        ("MIROC-ESM-CHEM", "rcp4p5", 2030),
         ("MIROC-ESM-CHEM", "rcp8p5", 2080),
-        ("000000000WATCH", "historical", 1980),
     ]:
         paths.append(
             get_source_path_wri_riverine_inundation(
@@ -380,6 +380,7 @@ def inundation_paths():
         )
     for model, scenario, year in [
         ("wtsub/95", "rcp8p5", "2080"),
+        ("wtsub/95", "rcp4p5", "2030"),
         ("wtsub", "historical", "hist"),
         ("nosub", "historical", "hist"),
     ]:


### PR DESCRIPTION
Remove exception for historical scenario in coastal and riverine selectors.
In _get_resource_source_path use the minimum year available.

Co-authored-by: Arfima Dev <dev@arfima.com>