### PR TITLE
Support historical scenario for score-based risk measures.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "physrisk-lib"
 # Could test changing the below to be sourced "dynamically"
 # dynamic = ['version']
-version = "0.41.0"
+version = "0.42.0"
 description = "OS-Climate Physical Risk Library"
 authors = [
     {name = "Joe Moorhouse",email = "5102656+joemoorhouse@users.noreply.github.com"},

--- a/src/physrisk/api/v1/impact_req_resp.py
+++ b/src/physrisk/api/v1/impact_req_resp.py
@@ -57,7 +57,7 @@ class AssetImpactRequest(BaseModel):
     # to be deprecated
     scenario: str = Field("rcp8p5", description="Name of scenario ('rcp8p5')")
     year: int = Field(
-        [2050],
+        2050,
         description="""Projection years (e.g. 2030, 2050, 2080). Any year before 2030,
         e.g. 1980, is treated as historical.""",
     )
@@ -72,7 +72,7 @@ class Category(int, Enum):
 
 
 class RiskMeasureDefinition(BaseModel):
-    measure_id: str = Field(None, description="Identifier for the risk measure.")
+    measure_id: str = Field("", description="Identifier for the risk measure.")
     label: str = Field(
         "<short description of the measure, e.g. fractional loss for 1-in-100 year event>",
         description="Short label for the measure quantity.",
@@ -85,7 +85,7 @@ class RiskMeasureDefinition(BaseModel):
 
 class RiskScoreValue(BaseModel):
     value: Category = Field(
-        "", description="Value of the score: red, amber, green, nodata."
+        Category.NODATA, description="Value of the score: red, amber, green, nodata."
     )
     label: str = Field(
         "",
@@ -128,7 +128,7 @@ class RiskMeasureKey(BaseModel):
 
 class RiskMeasuresForAssets(BaseModel):
     key: RiskMeasureKey
-    scores: List[int] = Field(None, description="Identifier for the risk measure.")
+    scores: List[int] = Field([0], description="Identifier for the risk measure.")
     measures_0: List[float]
     measures_1: Optional[List[float]]
 
@@ -156,14 +156,14 @@ class AcuteHazardCalculationDetails(BaseModel):
     hazard_distribution: Distribution
     vulnerability_distribution: VulnerabilityDistrib
     hazard_path: List[str] = Field(
-        "unknown", description="Path to the hazard indicator data source."
+        ["unknown"], description="Path to the hazard indicator data source."
     )
 
 
 class ImpactKey(BaseModel):
     hazard_type: str = Field("", description="Type of the hazard.")
-    scenario_id: str = Field(None, description="Identifier of the scenario.")
-    year: str = Field(None, description="Year of impact.")
+    scenario_id: str = Field("", description="Identifier of the scenario.")
+    year: str = Field("", description="Year of impact.")
 
 
 class AssetSingleImpact(BaseModel):

--- a/src/physrisk/data/pregenerated_hazard_model.py
+++ b/src/physrisk/data/pregenerated_hazard_model.py
@@ -138,19 +138,21 @@ class PregeneratedHazardModel(HazardModel):
                     )
         except Exception as err:
             # e.g. the requested data is unavailable
-            for _i, req in enumerate(batch):
+            for _, req in enumerate(batch):
                 failed_response = HazardDataFailedResponse(err)
                 responses[req] = failed_response
                 failures.append(failed_response)
 
         if any(failures):
-            logger.error(
-                f"{len(failures)} errors in batch (hazard_type={hazard_type.__name__}, indicator_id={indicator_id}, "
+            # only a warning: perhaps the caller does not expect data to be present for all
+            # year/scenario combinations.
+            logger.warning(
+                f"{len(failures)} requests failed in batch (hazard_type={hazard_type.__name__}, indicator_id={indicator_id}, "
                 f"scenario={scenario}, year={year}): (logs limited to first 3)"
             )
             errors = (str(i.error) for i in failures)
-            for _ in range(3):
-                logger.error(next(errors))
+            for _ in range(min(len(failures), 3)):
+                logger.warning(next(errors))
         return
 
 

--- a/src/physrisk/requests.py
+++ b/src/physrisk/requests.py
@@ -556,7 +556,7 @@ def _create_risk_measures(
     measures_for_assets: List[RiskMeasuresForAssets] = []
     for hazard_type in hazard_types:
         for scenario_id in scenarios:
-            for year in years:
+            for year in [None] if scenario_id == "historical" else years:
                 # we calculate and tag results for each scenario, year and hazard
                 score_key = RiskMeasureKey(
                     hazard_type=hazard_type.__name__,

--- a/src/physrisk/vulnerability_models/config_based_impact_curves.py
+++ b/src/physrisk/vulnerability_models/config_based_impact_curves.py
@@ -71,11 +71,11 @@ class VulnerabilityConfigItem(BaseModel):
         "curve/surface. 1 or 2 dimensional array.",
     )
     cap_of_points_x: Optional[float] = Field(
-        "", description="Cap of x (indicator/threshold)."
+        None, description="Cap of x (indicator/threshold)."
     )
-    cap_of_points_y: Optional[float] = Field("", description="Cap of y (impact).")
+    cap_of_points_y: Optional[float] = Field(None, description="Cap of y (impact).")
     activation_of_points_x: Optional[float] = Field(
-        "", description="Activation threshold of x (indicator/threshold)."
+        None, description="Activation threshold of x (indicator/threshold)."
     )
 
 

--- a/tests/risk_models/risk_models_test.py
+++ b/tests/risk_models/risk_models_test.py
@@ -64,7 +64,7 @@ class TestRiskModels(TestWithCredentials):
         )
         measure_ids_for_asset, definitions = model.populate_measure_definitions(assets)
         _, measures = model.calculate_risk_measures(
-            assets, prosp_scens=scenarios, years=years
+            assets, scenarios=scenarios, years=years
         )
 
         # how to get a score using the MeasureKey
@@ -293,7 +293,7 @@ class TestRiskModels(TestWithCredentials):
         )
 
     def test_via_requests(self):
-        scenarios = ["ssp585"]
+        scenarios = ["ssp585", "historical"]
         years = [2050]
 
         assets = self._create_assets()
@@ -386,7 +386,7 @@ class TestRiskModels(TestWithCredentials):
         )
         measure_ids_for_asset, definitions = model.populate_measure_definitions(assets)
         _, measures = model.calculate_risk_measures(
-            assets, prosp_scens=scenarios, years=years
+            assets, scenarios=scenarios, years=years
         )
         np.testing.assert_approx_equal(
             measures[MeasureKey(assets[0], scenarios[0], years[0], Wind)].measure_0,


### PR DESCRIPTION
Originally score-based risk measures were intended to be limited to future scenarios, since in general these compare to historical baseline. However there is request for historical also (mainly where scores are not comparative). 