### PR TITLE
Fix tile bug; update inventory; add support for NetCDF coords; update default bucket

### DIFF
--- a/src/physrisk/api/v1/hazard_data.py
+++ b/src/physrisk/api/v1/hazard_data.py
@@ -107,6 +107,12 @@ class HazardResource(BaseModel):
     scenarios: List[Scenario] = Field(
         description="Climate change scenarios for which the indicator is available."
     )
+    store_netcdf_coords: bool = Field(
+        False,
+        description="If True, NetCDF-style coordinates are also stored, which allows XArray to read the array \
+            natively. In this case, path still points to the array; the coordinates are stored in an array group \
+                in the parent folder. That is, path should be in the form path_to_array_group/array_group/array",
+    )
     units: str = Field(description="Units of the hazard indicator.")
 
     def expand(self):

--- a/src/physrisk/data/image_creator.py
+++ b/src/physrisk/data/image_creator.py
@@ -54,8 +54,14 @@ class ImageCreator:
                 path, colormap, tile=tile, min_value=min_value, max_value=max_value
             )
         except Exception as e:
-            logger.exception(e)
-            image = Image.fromarray(np.array([[0]]), mode="RGBA")
+            # if we are creating a whole image that does not exist, we log the error
+            # and return a empty image; but if creating a tile we let the error propagate
+            # because many map controls expect an HTTPException in such cases.
+            if tile is None:
+                logger.exception(e)
+                image = Image.fromarray(np.array([[0]]), mode="RGBA")
+            else:
+                raise
         image_bytes = io.BytesIO()
         image.save(image_bytes, format=format)
         return image_bytes.getvalue()

--- a/src/physrisk/data/static/hazard/inventory.json
+++ b/src/physrisk/data/static/hazard/inventory.json
@@ -49,6 +49,7 @@
                 "index_values": null,
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "historical",
@@ -110,6 +111,7 @@
                 ],
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "rcp4p5",
@@ -181,6 +183,7 @@
                 ],
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "rcp4p5",
@@ -252,6 +255,7 @@
                 ],
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "rcp4p5",
@@ -323,6 +327,7 @@
                 ],
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "rcp4p5",
@@ -394,6 +399,7 @@
                 ],
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "rcp4p5",
@@ -465,6 +471,7 @@
                 ],
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "historical",
@@ -526,6 +533,7 @@
                 ],
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "rcp4p5",
@@ -597,6 +605,7 @@
                 ],
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "rcp4p5",
@@ -668,6 +677,7 @@
                 ],
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "rcp4p5",
@@ -739,6 +749,7 @@
                 ],
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "historical",
@@ -800,6 +811,7 @@
                 ],
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "rcp4p5",
@@ -871,6 +883,7 @@
                 ],
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "rcp4p5",
@@ -942,6 +955,7 @@
                 ],
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "rcp4p5",
@@ -1022,6 +1036,7 @@
                 "index_values": null,
                 "source": "map_array"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "historical",
@@ -1105,6 +1120,7 @@
                 "index_values": null,
                 "source": "map_array"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "ssp126",
@@ -1180,6 +1196,7 @@
                 "index_values": null,
                 "source": "map_array"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "ssp126",
@@ -1255,6 +1272,7 @@
                 "index_values": null,
                 "source": "map_array"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "ssp126",
@@ -1330,6 +1348,7 @@
                 "index_values": null,
                 "source": "map_array"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "ssp126",
@@ -1405,6 +1424,7 @@
                 "index_values": null,
                 "source": "map_array"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "ssp126",
@@ -1480,6 +1500,7 @@
                 "index_values": null,
                 "source": "map_array"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "ssp126",
@@ -1555,6 +1576,7 @@
                 "index_values": null,
                 "source": "map_array"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "ssp126",
@@ -1646,6 +1668,7 @@
                 "index_values": null,
                 "source": "map_array"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "historical",
@@ -1749,6 +1772,7 @@
                 "index_values": null,
                 "source": "map_array"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "historical",
@@ -1832,6 +1856,7 @@
                 "index_values": null,
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "historical",
@@ -1924,6 +1949,7 @@
                 ],
                 "source": "map_array"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "historical",
@@ -2022,6 +2048,7 @@
                 ],
                 "source": "map_array"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "historical",
@@ -2131,6 +2158,7 @@
                 ],
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "historical",
@@ -2260,6 +2288,7 @@
                 ],
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "historical",
@@ -2343,6 +2372,7 @@
                 ],
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "historical",
@@ -2452,6 +2482,7 @@
                 "index_values": null,
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "historical",
@@ -2537,6 +2568,7 @@
                 "index_values": null,
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "historical",
@@ -2622,6 +2654,7 @@
                 "index_values": null,
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "historical",
@@ -2707,6 +2740,7 @@
                 "index_values": null,
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "historical",
@@ -2792,6 +2826,7 @@
                 "index_values": null,
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "historical",
@@ -2877,6 +2912,7 @@
                 "index_values": null,
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "historical",
@@ -2920,7 +2956,12 @@
             "indicator_model_gcm": "{gcm}",
             "params": {
                 "gcm": [
-                    "MIROC6"
+                    "ACCESS-CM2",
+                    "CMCC-ESM2",
+                    "CNRM-CM6-1",
+                    "MPI-ESM1-2-LR",
+                    "MIROC6",
+                    "NorESM2-MM"
                 ]
             },
             "display_name": "Drought SPEI index",
@@ -2938,7 +2979,7 @@
                     "nodata_index": 0,
                     "units": "months/year"
                 },
-                "path": "drought/osc/v1/months_spei12m_below_index_{gcm}_{scenario}_{year}_map",
+                "path": "maps/drought/osc/v1/months_spei12m_below_index_{gcm}_{scenario}_{year}_map",
                 "bounds": [
                     [
                         -180.0,
@@ -2974,6 +3015,7 @@
                 ],
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "ssp585",
@@ -3015,6 +3057,7 @@
                 "index_values": null,
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "historical",
@@ -3066,6 +3109,7 @@
                 "index_values": null,
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "historical",
@@ -3085,6 +3129,82 @@
                     "years": [
                         2035,
                         2085
+                    ]
+                }
+            ],
+            "units": "years"
+        },
+        {
+            "hazard_type": "RiverineInundation",
+            "group_id": "",
+            "path": "inundation/flopros_riverine/v1/flood_sop/sop",
+            "indicator_id": "flood_sop",
+            "indicator_model_id": "flopros",
+            "indicator_model_gcm": "",
+            "params": {},
+            "display_name": "Standard of protection (FLOPROS)",
+            "display_groups": [],
+            "description": "Global data set of protection levels for riverine and coastal flood, based on the [FLOPROS database] (https://nhess.copernicus.org/articles/16/1049/2016/). For each of coastal and riverine inundation, the dataset provides for every location a minimum (\"min\") and maximum (\"max\") protection, specified as a return period in years; the min and max reflects in uncertainty in the protection level. The return period indicates that the location is protected against flood events with that return period (e.g. 100 years indicates that the location is protected against 1-in-100 year flood events). Finding the equivalent flood depth protection level additionally requires a flood depth indicator data set.\n",
+            "map": {
+                "colormap": {
+                    "min_index": 1,
+                    "min_value": 0.0,
+                    "max_index": 255,
+                    "max_value": 1500.0,
+                    "name": "flare",
+                    "nodata_index": 0,
+                    "units": "years"
+                },
+                "path": "maps/inundation/flopros_riverine/v1/flood_sop_map",
+                "bounds": [],
+                "bbox": [],
+                "index_values": null,
+                "source": "map_array_pyramid"
+            },
+            "store_netcdf_coords": true,
+            "scenarios": [
+                {
+                    "id": "historical",
+                    "years": [
+                        1985
+                    ]
+                }
+            ],
+            "units": "years"
+        },
+        {
+            "hazard_type": "CoastalInundation",
+            "group_id": "",
+            "path": "inundation/flopros_coastal/v1/flood_sop/sop",
+            "indicator_id": "flood_sop",
+            "indicator_model_id": "flopros",
+            "indicator_model_gcm": "",
+            "params": {},
+            "display_name": "Standard of protection (FLOPROS)",
+            "display_groups": [],
+            "description": "Global data set of protection levels for riverine and coastal flood, based on the [FLOPROS database] (https://nhess.copernicus.org/articles/16/1049/2016/). For each of coastal and riverine inundation, the dataset provides for every location a minimum (\"min\") and maximum (\"max\") protection, specified as a return period in years; the min and max reflects in uncertainty in the protection level. The return period indicates that the location is protected against flood events with that return period (e.g. 100 years indicates that the location is protected against 1-in-100 year flood events). Finding the equivalent flood depth protection level additionally requires a flood depth indicator data set.\n",
+            "map": {
+                "colormap": {
+                    "min_index": 1,
+                    "min_value": 0.0,
+                    "max_index": 255,
+                    "max_value": 1500.0,
+                    "name": "flare",
+                    "nodata_index": 0,
+                    "units": "years"
+                },
+                "path": "maps/inundation/flopros_coastal/v1/flood_sop_map",
+                "bounds": [],
+                "bbox": [],
+                "index_values": null,
+                "source": "map_array_pyramid"
+            },
+            "store_netcdf_coords": true,
+            "scenarios": [
+                {
+                    "id": "historical",
+                    "years": [
+                        1985
                     ]
                 }
             ],
@@ -3139,6 +3259,7 @@
                 "index_values": null,
                 "source": "map_array_pyramid"
             },
+            "store_netcdf_coords": false,
             "scenarios": [
                 {
                     "id": "historical",

--- a/src/physrisk/hazard_models/core_hazards.py
+++ b/src/physrisk/hazard_models/core_hazards.py
@@ -8,6 +8,7 @@ from physrisk.kernel import hazards
 from physrisk.kernel.hazards import (
     ChronicHeat,
     CoastalInundation,
+    Drought,
     RiverineInundation,
     Wind,
 )
@@ -186,6 +187,7 @@ class CoreInventorySourcePaths(InventorySourcePaths):
         self.add_selector(
             ChronicHeat, "mean/degree/days/above/32c", self._select_chronic_heat
         )
+        self.add_selector(Drought, "months/spei12m/below/index", self._select_drought)
         self.add_selector(
             RiverineInundation,
             "flood_depth",
@@ -220,6 +222,15 @@ class CoreInventorySourcePaths(InventorySourcePaths):
         hint: Optional[HazardDataHint] = None,
     ):
         return candidates.with_model_id("wtsub/95").first()
+
+    @staticmethod
+    def _select_drought(
+        candidates: ResourceSubset,
+        scenario: str,
+        year: int,
+        hint: Optional[HazardDataHint] = None,
+    ):
+        return candidates.with_model_gcm("MIROC6").first()
 
     @staticmethod
     def _select_riverine_inundation(


### PR DESCRIPTION
A few smallish changes:
- Fix bug whereby image tiles were not displaying when over-zoomed.
- Add support for arrays which are written in Xarray standard with support for NetCDF-style co-ordinates.
- Update inventory.
- Move default S3 bucket to ASDI bucket.