### PR TITLE
Feat: Add standard release engineering workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,17 @@
----
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 version: 2
 updates:
-  # prettier-ignore
-  - package-ecosystem: "pip"  # See documentation for possible values
-    # prettier-ignore
-    directory: "/"  # Location of package manifests
-    commit-message:
-      prefix: "[dependabot] Chore:"
-    open-pull-requests-limit: 1
-    schedule:
-      interval: "weekly"
-
   - package-ecosystem: "github-actions"
     directory: "/"
-    commit-message:
-      prefix: "[dependabot] Chore:"
-    open-pull-requests-limit: 3
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "Chore"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "Chore"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,70 @@
+---
+# SPDX-FileCopyrightText: 2021 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+sort-direction: ascending
+categories:
+  - title: ":boom: Breaking Change :boom:"
+    labels:
+      - "breaking-change"
+  - title: ":zap: Enhancements :zap:"
+    labels:
+      - "enhancement"
+  - title: ":sparkles: New Features :sparkles:"
+    labels:
+      - "feature"
+  - title: ":bug: Bug Fixes :bug:"
+    labels:
+      - "fix"
+      - "bugfix"
+      - "bug"
+  - title: ":wrench: Maintenance :wrench:"
+    labels:
+      - "chore"
+      - "documentation"
+      - "maintenance"
+      - "repo"
+      - "dependencies"
+      - "github_actions"
+      - "refactor"
+  - title: ":mortar_board: Code Quality :mortar_board:"
+    labels:
+      - "code-quality"
+      - "CI"
+      - "test"
+autolabeler:
+  - label: "breaking-change"
+    title:
+      - "/!:/i"
+  - label: "feature"
+    title:
+      - "/feat:/i"
+  - label: "bug"
+    title:
+      - "/fix:/i"
+  - label: "refactor"
+    title:
+      - "/refactor:/i"
+  - label: "code-quality"
+    title:
+      - "/test:/i"
+  - label: "CI"
+    title:
+      - "/ci:/i"
+  - label: "chore"
+    title:
+      - "/chore:/i"
+  - label: "documentation"
+    title:
+      - "/docs:/i"
+# yamllint disable rule:line-length
+template: |
+  [![Downloads for this release](https://img.shields.io/github/downloads/os-climate/osc-github-devops/v$RESOLVED_VERSION/total.svg)](https://github.com/os-climate/osc-github-devops/releases/v$RESOLVED_VERSION)
+
+  $CHANGES
+
+  ## Links
+  - [Submit bugs/feature requests](https://github.com/os-climate/osc-github-devops/issues)

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,34 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+name: "CodeQL Scan"
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main", "master"]
+    paths:
+      - "!.github/**"
+      - "!.docs/**"
+  schedule:
+    - cron: "40 4 * * 0"
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  scan:
+    name: "CodeQL"
+    # yamllint disable-line rule:line-length
+    uses: lfit/releng-reusable-workflows/.github/workflows/reuse-python-codeql.yaml@fdcd10bc0fe174fe7d8834b2ba3a30159b4bf0bf # v0.2.14
+    permissions:
+      security-events: write
+      # required to fetch internal or private CodeQL packs
+      packages: read
+      # only required for workflows in private repositories
+      actions: read
+      contents: read

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -1,0 +1,48 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+# Updates Python dependencies and raises a pull request with changes
+name: 'Python Dependencies Update ♻️'
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 8 1 * *'
+  push:
+    branches:
+      - 'main'
+      - 'master'
+    paths:
+      - '**'
+      - '!.github/**'
+      - '!.*'
+      - '!pdm.lock'
+      - '!tox.ini'
+
+env:
+  python-version: 3.11
+
+permissions: {}
+
+jobs:
+  python-dependencies:
+    name: 'Update Python Dependencies'
+    runs-on: 'ubuntu-latest'
+    permissions:
+      # IMPORTANT: mandatory to raise the PR
+      id-token: write
+      pull-requests: write
+      repository-projects: write
+      contents: write
+    steps:
+      # Harden the runner used by this workflow
+      - uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/python-dependencies-update-action@3b2b40361716c4f940eaf6876aa9e4841c58b146 # v0.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,52 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+name: "Release Drafter"
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - main
+      - master
+
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+  # pull_request_target event is required for autolabeler to support PRs from forks
+  # pull_request_target:
+  #   types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
+    runs-on: ubuntu-24.04
+    steps:
+      # Harden the runner used by this workflow
+      - uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
+      # (Optional) GitHub Enterprise requires GHE_HOST variable set
+      #- name: Set GHE_HOST
+      #  run: |
+      #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
+
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
+        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+        # with:
+        #   config-name: my-config.yml
+        #   disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security-scans.yaml
+++ b/.github/workflows/security-scans.yaml
@@ -1,0 +1,50 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: "Security Scans"
+on:
+  workflow_dispatch:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: "31 3 * * 0"
+  push:
+    branches: ["main", "master"]
+    paths:
+      - "**"
+      - "!.github/**"
+
+# Declare default permissions as none.
+permissions: {}
+
+jobs:
+  sonatype-lifecycle:
+    name: "Sonatype Lifecycle"
+    # yamllint disable-line rule:line-length
+    uses: lfit/releng-reusable-workflows/.github/workflows/reuse-sonatype-lifecycle.yaml@fdcd10bc0fe174fe7d8834b2ba3a30159b4bf0bf # v0.2.14
+    secrets:
+      NEXUS_IQ_PASSWORD: ${{ secrets.NEXUS_IQ_PASSWORD }}
+
+  # Scan results are found at: https://sonarcloud.io/login
+  sonarqube-cloud:
+    name: "SonarQube Cloud"
+    # yamllint disable-line rule:line-length
+    uses: lfit/releng-reusable-workflows/.github/workflows/reuse-sonarqube-cloud.yaml@fdcd10bc0fe174fe7d8834b2ba3a30159b4bf0bf # v0.2.14
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+      # Uncomment the permissions below if installing in a private repository.
+      # contents: read
+      # actions: read
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/verify-gha-versions.yaml
+++ b/.github/workflows/verify-gha-versions.yaml
@@ -1,0 +1,32 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+# Verifies action/workflow calls are pinned to SHA commit values
+name: 'Check GitHub Actions/Workflows'
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - 'main'
+      - 'master'
+    paths: ['.github/**']
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  check-actions:
+    name: 'Pinned Versions'
+    runs-on: 'ubuntu-latest'
+    permissions:
+      contents: read
+    steps:
+      - name: 'Check Workflows'
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/pinned-versions-action@cde1c07452cbfcc2bef79fd4b14e90e5efbd8fc2 # v0.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b  # frozen: v5.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -16,13 +16,13 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.5
+    rev: a30f0d816e5062a67d87c8de753cfe499672b959  # frozen: v1.5.5
     hooks:
       - id: remove-tabs
         exclude: ^.*(\.(tsv)|Makefile)$
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.7
+    rev: d19233b89771be2d89273f163f5edc5a39bbc34a  # frozen: v0.11.12
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --config=pyproject.toml]
@@ -38,7 +38,7 @@ repos:
           then /bin/mkdir .mypy_cache; fi; exit 0'
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.11.1"
+    rev: "7010b10a09f65cd60a23c207349b539aa36dbec1"  # frozen: v1.16.0
     hooks:
       - id: mypy
         verbose: true


### PR DESCRIPTION
Enables advanced configuration for dependabot/codeql, adds sonar-X scan types, new Python dependencies update action for PDM, release drafter for automatic release note generation from conventional commits. Adds a verification check for Github workflow to ensure they are using commit SHA pins and not version numbers. Updates the listing tools and pins them to commit values.