### PR TITLE
Refactor hazard_scope to allow indicator_id drilldown

### DIFF
--- a/src/physrisk/api/v1/impact_req_resp.py
+++ b/src/physrisk/api/v1/impact_req_resp.py
@@ -171,7 +171,9 @@ class ScoreBasedRiskMeasureSetDefinition(BaseModel):
     score_definitions: Dict[str, ScoreBasedRiskMeasureDefinition]
     # where drill-down by hazard indicator ID is relevant, give the measure IDs for each
     # (hazard type, indicator ID) combination :
-    asset_measure_ids_for_hazard_drilldown: dict[str, dict[str, list[str]]] = Field(default_factory=dict)
+    asset_measure_ids_for_hazard_drilldown: dict[str, dict[str, list[str]]] = Field(
+        default_factory=dict
+    )
 
 
 class RiskMeasures(BaseModel):
@@ -284,7 +286,13 @@ class RiskMeasuresHelper:
             hazard_indicator_id=key.hazard_indicator_id,
         )
 
-    def get_measure(self, hazard_type: str, scenario: str, year: int, hazard_indicator_id: str | None = None):
+    def get_measure(
+        self,
+        hazard_type: str,
+        scenario: str,
+        year: int,
+        hazard_indicator_id: str | None = None,
+    ):
         measure_key = self.Key(
             hazard_type=hazard_type,
             scenario_id=scenario,
@@ -299,14 +307,20 @@ class RiskMeasuresHelper:
             measure.scores,
             [measure.measures_0, measure.measures_1],
         )  # scores for each asset
-        
+
         if hazard_indicator_id is None:
             # measure IDs for each asset (for the hazard type in question)
-            measure_ids = self.measure_definition.asset_measure_ids_for_hazard[hazard_type]
+            measure_ids = self.measure_definition.asset_measure_ids_for_hazard[
+                hazard_type
+            ]
         else:
             # measure IDs for each asset (for the hazard type and indicator ID in question)
-            measure_ids = self.measure_definition.asset_measure_ids_for_hazard_drilldown[hazard_type][hazard_indicator_id]
-        
+            measure_ids = (
+                self.measure_definition.asset_measure_ids_for_hazard_drilldown[
+                    hazard_type
+                ][hazard_indicator_id]
+            )
+
         # measure definitions for each asset
         measure_definitions = [
             self.measure_definition.score_definitions[mid] if mid != "na" else None

--- a/src/physrisk/api/v1/impact_req_resp.py
+++ b/src/physrisk/api/v1/impact_req_resp.py
@@ -21,6 +21,10 @@ class CalcSettings(BaseModel):
         description="Comma separated list of hazards to include in analysis.",
         examples=["RiverineInundation,Wind", "Hail,Fire"],
     )
+    hazard_scope_by_indicator: Optional[Dict[str, List[str] | None]] = Field(
+        default=None,
+        description="Dictionary of hazards and corresponding indicator ids to include in analysis.",
+    )
 
 
 class AssetImpactRequest(BaseModel):

--- a/src/physrisk/api/v1/impact_req_resp.py
+++ b/src/physrisk/api/v1/impact_req_resp.py
@@ -171,9 +171,7 @@ class ScoreBasedRiskMeasureSetDefinition(BaseModel):
     score_definitions: Dict[str, ScoreBasedRiskMeasureDefinition]
     # where drill-down by hazard indicator ID is relevant, give the measure IDs for each
     # (hazard type, indicator ID) combination :
-    asset_measure_ids_for_hazard_drilldown: Optional[
-        dict[str, dict[str, list[str]]]
-    ] = None
+    asset_measure_ids_for_hazard_drilldown: dict[str, dict[str, list[str]]] = Field(default_factory=dict)
 
 
 class RiskMeasures(BaseModel):
@@ -283,14 +281,16 @@ class RiskMeasuresHelper:
             scenario_id=key.scenario_id,
             year=key.year,
             measure_id=key.measure_id,
+            hazard_indicator_id=key.hazard_indicator_id,
         )
 
-    def get_measure(self, hazard_type: str, scenario: str, year: int):
+    def get_measure(self, hazard_type: str, scenario: str, year: int, hazard_indicator_id: str | None = None):
         measure_key = self.Key(
             hazard_type=hazard_type,
             scenario_id=scenario,
             year=str(year),
             measure_id=self.measure_set_id,
+            hazard_indicator_id=hazard_indicator_id,
         )
         if measure_key not in self.measures:
             return None, None, None
@@ -299,8 +299,14 @@ class RiskMeasuresHelper:
             measure.scores,
             [measure.measures_0, measure.measures_1],
         )  # scores for each asset
-        # measure IDs for each asset (for the hazard type in question)
-        measure_ids = self.measure_definition.asset_measure_ids_for_hazard[hazard_type]
+        
+        if hazard_indicator_id is None:
+            # measure IDs for each asset (for the hazard type in question)
+            measure_ids = self.measure_definition.asset_measure_ids_for_hazard[hazard_type]
+        else:
+            # measure IDs for each asset (for the hazard type and indicator ID in question)
+            measure_ids = self.measure_definition.asset_measure_ids_for_hazard_drilldown[hazard_type][hazard_indicator_id]
+        
         # measure definitions for each asset
         measure_definitions = [
             self.measure_definition.score_definitions[mid] if mid != "na" else None
@@ -319,3 +325,4 @@ class RiskMeasuresHelper:
         scenario_id: str
         year: str
         measure_id: str
+        hazard_indicator_id: str | None = None

--- a/src/physrisk/api/v1/impact_req_resp.py
+++ b/src/physrisk/api/v1/impact_req_resp.py
@@ -224,6 +224,7 @@ class AssetSingleImpact(BaseModel):
         value of the asset ('damage') or disruption, expressed as fractional decrease in the revenue attributable
         to the asset.""",
     )
+    hazard_indicator_id: str = Field("", description="The ID of the hazard indicator.")
     impact_distribution: Optional[Distribution] = Field(
         None, description="Impact as probability distribution."
     )

--- a/src/physrisk/container.py
+++ b/src/physrisk/container.py
@@ -67,7 +67,7 @@ class ZarrHazardModelFactory(HazardModelFactory):
 
 class DictBasedVulnerabilityModelsFactory(PVulnerabilityModelsFactory):
     def vulnerability_models(
-        self, hazard_scope: Optional[Set[Type[Hazard]]] = None
+        self, hazard_scope: dict[type[Hazard], set[str] | None] | None = None
     ) -> PVulnerabilityModels:
         return DictBasedVulnerabilityModels(
             calc.alternate_default_vulnerability_models_scores()

--- a/src/physrisk/container.py
+++ b/src/physrisk/container.py
@@ -1,4 +1,4 @@
-from typing import Dict, MutableMapping, Optional, Set, Type
+from typing import Dict, MutableMapping, Optional
 
 from dependency_injector import containers, providers
 

--- a/src/physrisk/hazard_models/core_hazards.py
+++ b/src/physrisk/hazard_models/core_hazards.py
@@ -342,9 +342,5 @@ def cmip6_scenario_to_rcp(scenario: str):
         return scenario
 
 
-def get_default_source_path_provider(inventory: Inventory = EmbeddedInventory()):
-    return CoreInventorySourcePaths(inventory)
-
-
 def get_default_source_paths(inventory: Inventory = EmbeddedInventory()):
     return CoreInventorySourcePaths(inventory)

--- a/src/physrisk/hazard_models/core_hazards.py
+++ b/src/physrisk/hazard_models/core_hazards.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from pathlib import PosixPath, PurePosixPath
+from pathlib import PurePosixPath
 from typing import Dict, Iterable, List, NamedTuple, Optional, Protocol, Sequence, Type
 
 from physrisk.api.v1.hazard_data import HazardResource
@@ -135,8 +135,8 @@ class InventorySourcePaths(SourcePaths):
             # is this a pyramid of tiles?
             is_pyramid = resource.map.source != "map_array"
             path = (
-                str(PosixPath(resource.path).with_name(resource.map.path))
-                if len(PosixPath(resource.map.path).parts) == 1
+                str(PurePosixPath(resource.path).with_name(resource.map.path))
+                if len(PurePosixPath(resource.map.path).parts) == 1
                 else resource.map.path
             )
             if is_pyramid:

--- a/src/physrisk/kernel/hazards.py
+++ b/src/physrisk/kernel/hazards.py
@@ -131,5 +131,5 @@ def all_hazards():
     ]
 
 
-def hazard_class(name: str):
+def hazard_class(name: str) -> Type[Hazard]:
     return getattr(sys.modules[__name__], name)

--- a/src/physrisk/kernel/impact_distrib.py
+++ b/src/physrisk/kernel/impact_distrib.py
@@ -1,6 +1,6 @@
 from enum import Enum
 import sys
-from typing import Optional, Sequence, Type, Union
+from typing import Sequence, Type, Union
 
 import numpy as np
 
@@ -30,7 +30,7 @@ class ImpactDistrib:
         hazard_type: Type[Hazard],
         impact_bin_edges: Union[Sequence[float], np.ndarray],
         probabilities: Union[Sequence[float], np.ndarray],
-        hazard_indicator_id: Optional[str] = None,
+        hazard_indicator_id: str,
         impact_type: ImpactType = ImpactType.damage,
         path: Sequence[str] = [],
     ):

--- a/src/physrisk/kernel/impact_distrib.py
+++ b/src/physrisk/kernel/impact_distrib.py
@@ -44,9 +44,7 @@ class ImpactDistrib:
             path: Paths (unique identifiers) of the hazard indicator data sources used to calculate the impact distribution. Provides the main hazard indicator (specified by the ID), but also any additional hazard indicators. For example, for flood, 'flood_depth' but also standard of protection data sources.
         """
         self._hazard_type = hazard_type
-        self._hazard_indicator_id = (
-            sys.intern(hazard_indicator_id) if hazard_indicator_id is not None else None
-        )
+        self._hazard_indicator_id = sys.intern(hazard_indicator_id)
         self._impact_bin_edges = np.array(impact_bin_edges)
         self._impact_type = impact_type
         self._probabilities = np.array(probabilities)
@@ -127,7 +125,7 @@ class ImpactDistrib:
         return self._hazard_type
 
     @property
-    def hazard_indicator_id(self) -> str | None:
+    def hazard_indicator_id(self) -> str:
         return self._hazard_indicator_id
 
     @property

--- a/src/physrisk/kernel/vulnerability_distrib.py
+++ b/src/physrisk/kernel/vulnerability_distrib.py
@@ -26,7 +26,7 @@ class VulnerabilityDistrib:
         intensity_bins: Union[List[float], np.ndarray],
         impact_bins: Union[List[float], np.ndarray],
         prob_matrix: Union[List[List[float]], np.ndarray],
-        hazard_indicator_id: Optional[str] = None,
+        hazard_indicator_id: str,
     ):
         """Create a new vulnerability distribution.
         Args:

--- a/src/physrisk/kernel/vulnerability_distrib.py
+++ b/src/physrisk/kernel/vulnerability_distrib.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import List, Union
 
 import numpy as np
 

--- a/src/physrisk/kernel/vulnerability_distrib.py
+++ b/src/physrisk/kernel/vulnerability_distrib.py
@@ -50,7 +50,7 @@ class VulnerabilityDistrib:
         return self._hazard_type
 
     @property
-    def hazard_indicator_id(self) -> Optional[str]:
+    def hazard_indicator_id(self) -> str:
         return self._hazard_indicator_id
 
     def intensity_bin_bounds(self):

--- a/src/physrisk/kernel/vulnerability_model.py
+++ b/src/physrisk/kernel/vulnerability_model.py
@@ -133,7 +133,7 @@ class VulnerabilityModels(Protocol):
 
 class VulnerabilityModelsFactory(Protocol):
     def vulnerability_models(
-        self, hazard_scope: Optional[Set[Type[Hazard]]] = None
+        self, hazard_scope: dict[type[Hazard], set[str] | None] | None = None
     ) -> VulnerabilityModels:
         """Create a VulnerabilityModels instance, that can based on a number of options.
         Although no options used at present, implemented this way in order to add in future

--- a/src/physrisk/kernel/vulnerability_model.py
+++ b/src/physrisk/kernel/vulnerability_model.py
@@ -6,7 +6,6 @@ from typing import (
     Optional,
     Protocol,
     Sequence,
-    Set,
     Tuple,
     Type,
     Union,

--- a/src/physrisk/requests.py
+++ b/src/physrisk/requests.py
@@ -208,9 +208,14 @@ class Requester:
             interpolation=request.calc_settings.hazard_interp,
             provider_max_requests=request.provider_max_requests,
         )
-        
-        if request.calc_settings.hazard_scope is not None and request.calc_settings.hazard_scope_by_indicator is not None:
-            raise ValueError("Cannot specify both hazard_scope and hazard_scope_by_indicator")
+
+        if (
+            request.calc_settings.hazard_scope is not None
+            and request.calc_settings.hazard_scope_by_indicator is not None
+        ):
+            raise ValueError(
+                "Cannot specify both hazard_scope and hazard_scope_by_indicator"
+            )
         hazard_scope: dict[type[Hazard], set[str] | None] | None = None
         if request.calc_settings.hazard_scope is not None:
             hazard_scope = {
@@ -222,7 +227,7 @@ class Requester:
                 hazard_class(h): set(inds) if inds is not None else None
                 for h, inds in request.calc_settings.hazard_scope_by_indicator.items()
             }
-        
+
         vulnerability_models = self.vulnerability_models_factory.vulnerability_models(
             hazard_scope=hazard_scope
         )

--- a/src/physrisk/requests.py
+++ b/src/physrisk/requests.py
@@ -208,13 +208,21 @@ class Requester:
             interpolation=request.calc_settings.hazard_interp,
             provider_max_requests=request.provider_max_requests,
         )
+        
+        if request.calc_settings.hazard_scope is not None and request.calc_settings.hazard_scope_by_indicator is not None:
+            raise ValueError("Cannot specify both hazard_scope and hazard_scope_by_indicator")
+        hazard_scope: dict[type[Hazard], set[str] | None] | None = None
         if request.calc_settings.hazard_scope is not None:
-            hazard_scope = set(
-                hazard_class(h.strip())
+            hazard_scope = {
+                hazard_class(h.strip()): None
                 for h in request.calc_settings.hazard_scope.split(",")
-            )
-        else:
-            hazard_scope = None
+            }
+        if request.calc_settings.hazard_scope_by_indicator is not None:
+            hazard_scope = {
+                hazard_class(h): set(inds) if inds is not None else None
+                for h, inds in request.calc_settings.hazard_scope_by_indicator.items()
+            }
+        
         vulnerability_models = self.vulnerability_models_factory.vulnerability_models(
             hazard_scope=hazard_scope
         )

--- a/src/physrisk/requests.py
+++ b/src/physrisk/requests.py
@@ -636,6 +636,7 @@ def compile_asset_impacts(
                 hazard_impacts = AssetSingleImpact(
                     key=key,
                     impact_type="n/a",
+                    hazard_indicator_id="n/a",
                     impact_distribution=None,
                     impact_exceedance=None,
                     impact_mean=float("nan"),
@@ -647,6 +648,7 @@ def compile_asset_impacts(
                 hazard_impacts = AssetSingleImpact(
                     key=key,
                     impact_type=v.impact.impact_type.name,
+                    hazard_indicator_id=v.impact.hazard_indicator_id,
                     impact_exceedance=ExceedanceCurve(
                         values=sig_figures(impact_exceedance.values),
                         exceed_probabilities=sig_figures(impact_exceedance.probs),
@@ -667,7 +669,8 @@ def compile_asset_impacts(
 
     for a, imps in ordered_impacts.items():
         ordered_impacts[a] = sorted(
-            imps, key=lambda x: x.key.hazard_type + x.key.scenario_id + x.key.year
+            imps,
+            key=lambda x: x.key.hazard_type + x.key.scenario_id + x.key.year,
         )
     return [
         AssetLevelImpact(asset_id=k.id if k.id is not None else "", impacts=v)

--- a/src/physrisk/vulnerability_models/real_estate_models.py
+++ b/src/physrisk/vulnerability_models/real_estate_models.py
@@ -277,7 +277,7 @@ class CoolingModel(VulnerabilityModelBase):
         )  # kWh of electricity required for heat removal
         # this is non-probabilistic model: probability of 1 of electricity use
         return ImpactDistrib(
-            ChronicHeat, 
+            ChronicHeat,
             [annual_electricity, annual_electricity],
             [1],
             hazard_indicator_id=self.indicator_id,

--- a/src/physrisk/vulnerability_models/real_estate_models.py
+++ b/src/physrisk/vulnerability_models/real_estate_models.py
@@ -277,5 +277,9 @@ class CoolingModel(VulnerabilityModelBase):
         )  # kWh of electricity required for heat removal
         # this is non-probabilistic model: probability of 1 of electricity use
         return ImpactDistrib(
-            ChronicHeat, [annual_electricity, annual_electricity], [1], path=[data.path]
+            ChronicHeat, 
+            [annual_electricity, annual_electricity],
+            [1],
+            hazard_indicator_id=self.indicator_id,
+            path=[data.path],
         )

--- a/src/physrisk/vulnerability_models/vulnerability.py
+++ b/src/physrisk/vulnerability_models/vulnerability.py
@@ -184,7 +184,7 @@ class VulnerabilityModels(PVulnerabilityModels):
         
         if self.hazard_scope is None:
             return models
-        print(self.hazard_scope)
+
         filtered = []
         for model in models:
             if model.hazard_type not in self.hazard_scope:

--- a/src/physrisk/vulnerability_models/vulnerability.py
+++ b/src/physrisk/vulnerability_models/vulnerability.py
@@ -181,7 +181,7 @@ class VulnerabilityModels(PVulnerabilityModels):
                 models = self.models[ancestor_type]  # type:ignore
                 break
         assert models is not None
-        
+
         if self.hazard_scope is None:
             return models
 

--- a/src/physrisk/vulnerability_models/vulnerability.py
+++ b/src/physrisk/vulnerability_models/vulnerability.py
@@ -1,6 +1,6 @@
 import importlib.resources
 from importlib import import_module
-from typing import Dict, Optional, Sequence, Set
+from typing import Dict, Sequence
 
 import physrisk.kernel.assets
 from physrisk.kernel.assets import Asset

--- a/src/physrisk/vulnerability_models/vulnerability.py
+++ b/src/physrisk/vulnerability_models/vulnerability.py
@@ -6,6 +6,7 @@ import physrisk.kernel.assets
 from physrisk.kernel.assets import Asset
 from physrisk.kernel.hazards import (
     CoastalInundation,
+    Hazard,
     IndicatorData,
     PluvialInundation,
     RiverineInundation,
@@ -65,7 +66,7 @@ class VulnerabilityModelsFactory(PVulnerabilityModelsFactory):
 
     def vulnerability_models(
         self,
-        hazard_scope: Optional[Set[type]] = None,
+        hazard_scope: dict[type[Hazard], set[str] | None] | None = None,
         disable_api_calls=False,
     ) -> PVulnerabilityModels:
         return VulnerabilityModels(
@@ -99,7 +100,7 @@ class VulnerabilityModels(PVulnerabilityModels):
         config_based_selector: ConfigBasedImpactFunctionSelector,
         combined_selector: CombinedImpactFunctionSelector,
         programmatic_models: Dict[type[Asset], list[VulnerabilityModelBase]] = {},
-        hazard_scope: Optional[set[type[Asset]]] = None,
+        hazard_scope: dict[type[Hazard], set[str] | None] | None = None,
         disable_api_calls: bool = False,
         use_oed_hazus_curves=True,
     ):
@@ -180,9 +181,20 @@ class VulnerabilityModels(PVulnerabilityModels):
                 models = self.models[ancestor_type]  # type:ignore
                 break
         assert models is not None
-        if self.hazard_scope:
-            return [model for model in models if model.hazard_type in self.hazard_scope]
-        return models
+        
+        if self.hazard_scope is None:
+            return models
+        print(self.hazard_scope)
+        filtered = []
+        for model in models:
+            if model.hazard_type not in self.hazard_scope:
+                continue
+
+            indicator_scope = self.hazard_scope[model.hazard_type]
+            if indicator_scope is None or model.indicator_id in indicator_scope:
+                filtered.append(model)
+
+        return filtered
 
     @staticmethod
     def oed_hazus_models(selector: CombinedImpactFunctionSelector):

--- a/tests/kernel/test_asset_impact.py
+++ b/tests/kernel/test_asset_impact.py
@@ -66,7 +66,7 @@ class TestAssetImpact(unittest.TestCase):
     def test_standard_deviations(self):
         impact_bins = np.array([0.0, 0.5, 1.0, 1.5])
         probs = np.array([0.1, 0.2, 0.15])
-        impact = ImpactDistrib(RiverineInundation, impact_bins, probs)
+        impact = ImpactDistrib(RiverineInundation, impact_bins, probs, hazard_indicator_id="unknown")
         stddev = impact.standard_deviation()
         semi_stddev = impact.semi_standard_deviation()
         mean = impact.mean_impact()
@@ -96,7 +96,13 @@ class TestAssetImpact(unittest.TestCase):
 
         impact_bins = np.array([0.7, 0.7])
         probs = np.array([0.02])
-        impact = ImpactDistrib(RiverineInundation, impact_bins, probs, path=["unknown"])
+        impact = ImpactDistrib(
+            RiverineInundation, 
+            impact_bins, 
+            probs,
+            hazard_indicator_id="unknown",
+            path=["unknown"],
+        )
         mean = impact.mean_impact()
         stddev = impact.standard_deviation()
         semi_stddev = impact.semi_standard_deviation()
@@ -108,7 +114,13 @@ class TestAssetImpact(unittest.TestCase):
         # check potential edge cases relevant to semi standard deviation
         impact_bins = np.array([0.3, 0.3, 0.7, 0.8])
         probs = np.array([0.02, 0, 0.03])
-        impact = ImpactDistrib(RiverineInundation, impact_bins, probs, path=["unknown"])
+        impact = ImpactDistrib(
+            RiverineInundation, 
+            impact_bins, 
+            probs,
+            hazard_indicator_id="unknown",
+            path=["unknown"],
+        )
         mean = impact.mean_impact()
         stddev = impact.standard_deviation()
         semi_stddev = impact.semi_standard_deviation()
@@ -124,7 +136,13 @@ class TestAssetImpact(unittest.TestCase):
 
         impact_bins = np.array([0.1, 0.2, 0.5, 0.5, 0.8, 0.9])
         probs = np.array([1.0 / 3.0, 0, 1.0 / 3.0, 0, 1.0 / 3.0])
-        impact = ImpactDistrib(RiverineInundation, impact_bins, probs, path=["unknown"])
+        impact = ImpactDistrib(
+            RiverineInundation, 
+            impact_bins, 
+            probs,
+            hazard_indicator_id="unknown",
+            path=["unknown"],
+        )
         mean = impact.mean_impact()
         stddev = impact.standard_deviation()
         semi_stddev = impact.semi_standard_deviation()
@@ -200,7 +218,7 @@ class TestAssetImpact(unittest.TestCase):
         probs_w_cutoff = np.where(depth_bins[1:] <= cutoff_depth, 0.0, 1.0)
         # n_bins = len(probs)  # type: ignore
         vul = VulnerabilityDistrib(
-            type(RiverineInundation),
+            RiverineInundation, 
             depth_bins,
             impact_bins,
             np.diag(probs_w_cutoff),
@@ -208,12 +226,12 @@ class TestAssetImpact(unittest.TestCase):
         )  # np.eye(n_bins, n_bins))
         hazard_paths = ["unknown"]
         event = HazardEventDistrib(
-            type(RiverineInundation), depth_bins, probs, hazard_paths
+            RiverineInundation, depth_bins, probs, hazard_paths
         )  # type: ignore
 
         impact_prob = vul.prob_matrix.T @ event.prob
         impact = ImpactDistrib(
-            vul.event_type, vul.impact_bins, impact_prob, path=event.path
+            vul.event_type, vul.impact_bins, impact_prob, hazard_indicator_id=vul.hazard_indicator_id, path=event.path
         )
 
         mean = impact.mean_impact()

--- a/tests/kernel/test_asset_impact.py
+++ b/tests/kernel/test_asset_impact.py
@@ -66,7 +66,9 @@ class TestAssetImpact(unittest.TestCase):
     def test_standard_deviations(self):
         impact_bins = np.array([0.0, 0.5, 1.0, 1.5])
         probs = np.array([0.1, 0.2, 0.15])
-        impact = ImpactDistrib(RiverineInundation, impact_bins, probs, hazard_indicator_id="unknown")
+        impact = ImpactDistrib(
+            RiverineInundation, impact_bins, probs, hazard_indicator_id="unknown"
+        )
         stddev = impact.standard_deviation()
         semi_stddev = impact.semi_standard_deviation()
         mean = impact.mean_impact()
@@ -97,8 +99,8 @@ class TestAssetImpact(unittest.TestCase):
         impact_bins = np.array([0.7, 0.7])
         probs = np.array([0.02])
         impact = ImpactDistrib(
-            RiverineInundation, 
-            impact_bins, 
+            RiverineInundation,
+            impact_bins,
             probs,
             hazard_indicator_id="unknown",
             path=["unknown"],
@@ -115,8 +117,8 @@ class TestAssetImpact(unittest.TestCase):
         impact_bins = np.array([0.3, 0.3, 0.7, 0.8])
         probs = np.array([0.02, 0, 0.03])
         impact = ImpactDistrib(
-            RiverineInundation, 
-            impact_bins, 
+            RiverineInundation,
+            impact_bins,
             probs,
             hazard_indicator_id="unknown",
             path=["unknown"],
@@ -137,8 +139,8 @@ class TestAssetImpact(unittest.TestCase):
         impact_bins = np.array([0.1, 0.2, 0.5, 0.5, 0.8, 0.9])
         probs = np.array([1.0 / 3.0, 0, 1.0 / 3.0, 0, 1.0 / 3.0])
         impact = ImpactDistrib(
-            RiverineInundation, 
-            impact_bins, 
+            RiverineInundation,
+            impact_bins,
             probs,
             hazard_indicator_id="unknown",
             path=["unknown"],
@@ -218,20 +220,22 @@ class TestAssetImpact(unittest.TestCase):
         probs_w_cutoff = np.where(depth_bins[1:] <= cutoff_depth, 0.0, 1.0)
         # n_bins = len(probs)  # type: ignore
         vul = VulnerabilityDistrib(
-            RiverineInundation, 
+            RiverineInundation,
             depth_bins,
             impact_bins,
             np.diag(probs_w_cutoff),
             hazard_indicator_id="flood_depth",
         )  # np.eye(n_bins, n_bins))
         hazard_paths = ["unknown"]
-        event = HazardEventDistrib(
-            RiverineInundation, depth_bins, probs, hazard_paths
-        )  # type: ignore
+        event = HazardEventDistrib(RiverineInundation, depth_bins, probs, hazard_paths)  # type: ignore
 
         impact_prob = vul.prob_matrix.T @ event.prob
         impact = ImpactDistrib(
-            vul.event_type, vul.impact_bins, impact_prob, hazard_indicator_id=vul.hazard_indicator_id, path=event.path
+            vul.event_type,
+            vul.impact_bins,
+            impact_prob,
+            hazard_indicator_id=vul.hazard_indicator_id,
+            path=event.path,
         )
 
         mean = impact.mean_impact()

--- a/tests/risk_models/test_risk_models.py
+++ b/tests/risk_models/test_risk_models.py
@@ -700,7 +700,7 @@ class TestRiskModels(TestWithCredentials):
 
         class TestVulnerabilityModelsFactory(PVulnerabilityModelsFactory):
             def vulnerability_models(
-                self, hazard_scope: Optional[Set[Type[Hazard]]] = None
+                self, hazard_scope: dict[type[Hazard], set[str] | None] | None = None
             ) -> VulnerabilityModels:
                 return _vulnerability_models()
 

--- a/tests/risk_models/test_risk_models.py
+++ b/tests/risk_models/test_risk_models.py
@@ -1,6 +1,6 @@
 """Test asset impact calculations."""
 
-from typing import Dict, Optional, Sequence, Set, Type
+from typing import Dict, Optional, Sequence, Type
 
 import numpy as np
 from dependency_injector import providers

--- a/tests/risk_models/test_risk_models.py
+++ b/tests/risk_models/test_risk_models.py
@@ -126,7 +126,7 @@ def _config_based_vulnerability_models():
 
 
 def _vulnerability_models(
-    hazard_scope: Optional[Set[Type[Hazard]]] = None,
+    hazard_scope: dict[type[Hazard], set[str] | None] | None = None,
 ) -> VulnerabilityModels:
     model_set = [
         RealEstateCoastalInundationModel(),
@@ -638,7 +638,7 @@ class TestRiskModels(TestWithCredentials):
         # 1) for SSP245 Hail data not available
         model = AssetLevelRiskModel(
             hazard_model,
-            _vulnerability_models(set([Hail])),
+            _vulnerability_models({Hail: None}),
             {Asset: generic_measures, RealEstateAsset: generic_measures},
             NullAssetBasedPortfolioRiskMeasureCalculator(),
         )
@@ -660,7 +660,7 @@ class TestRiskModels(TestWithCredentials):
         ]
         model = AssetLevelRiskModel(
             hazard_model,
-            _vulnerability_models(set([ChronicHeat])),
+            _vulnerability_models({ChronicHeat: None}),
             {Asset: generic_measures, RealEstateAsset: generic_measures},
             NullAssetBasedPortfolioRiskMeasureCalculator(),
         )

--- a/tests/vulnerability_models/test_wind_models.py
+++ b/tests/vulnerability_models/test_wind_models.py
@@ -4,7 +4,7 @@ import tests.data.test_hazard_model_store as hms
 from physrisk.data.pregenerated_hazard_model import ZarrHazardModel
 from physrisk.hazard_models.core_hazards import (
     ResourceSubset,
-    get_default_source_path_provider,
+    get_default_source_paths,
 )
 from physrisk.kernel.assets import RealEstateAsset
 from physrisk.kernel.hazards import Wind
@@ -37,7 +37,7 @@ def test_wind_real_estate_model():
         transform,
     )
 
-    provider = get_default_source_path_provider()
+    provider = get_default_source_paths()
 
     def select_iris_osc(candidates: ResourceSubset, hint=None):
         return candidates.with_group_id("iris_osc").first()


### PR DESCRIPTION
The main change is that hazard_scope is now a dictionary internally, with hazard types as keys and a set of indicator ids as values or None. It supports the same functionality as before, of being able to select only those vulnerability models that correspond to certain hazards, but it now supports further filtering by indicator id. At the API level the user can now provide the usual hazard_scope, or the new hazard_scope_by_indicator. Internally, the requester validates that only one of them is set and parses it to the internal hazard_scope.

Additionally, we include some minor changes related to the indicator id drilldown implemented in #573:
* Adapt RiskMeasuresHelper to handle the keying by indicator id.
* Add hazard_indicator_id as an attribute of AssetImpactResult, needed to prevent information loss at the output regarding indicator id.
* Make hazard_indicator_id non optional (as internally it is always provided) in ImpactDistrib and VulnerabilityDistrib.
* Pass indicator id to ImpactDistrib in CoolingModel.

Finally, some minor unrelated clean up changes:
* Remove duplicated function get_default_source_path_provider in favour of get_default_source_paths.
* Change some path transformations to PurePosixPaths.
* Make asset_measure_ids_for_hazard_drilldown non optional in ScoreBasedRiskMeasureSetDefinition as it is always provided, the empy dict serves as the null value.

Co-authored-by: Juan Román Roche [jroman@arfimaconsulting.com](mailto:jroman@arfimaconsulting.com)
Co-authored-by: Violeta Crespo Cobas [vcrespo@arfima.com](mailto:vcrespo@arfima.com)
Co-authored-by: Arfima Dev [dev@arfima.com](mailto:dev@arfima.com)

Signed-off-by: Juan Román Roche [jroman@arfimaconsulting.com](mailto:jroman@arfimaconsulting.com)