### PR TITLE
Add interpolate_years to calc_settings to make it configurable. 

### DIFF
--- a/src/physrisk/api/v1/hazard_data.py
+++ b/src/physrisk/api/v1/hazard_data.py
@@ -251,6 +251,7 @@ class HazardDataRequest(BaseHazardRequest):
     """
 
     interpolation: str = "floor"
+    interpolate_years: bool = True
     provider_max_requests: Dict[str, int] = Field(
         {},
         description="The maximum permitted number of \

--- a/src/physrisk/api/v1/impact_req_resp.py
+++ b/src/physrisk/api/v1/impact_req_resp.py
@@ -21,6 +21,10 @@ class CalcSettings(BaseModel):
         description="Comma separated list of hazards to include in analysis.",
         examples=["RiverineInundation,Wind", "Hail,Fire"],
     )
+    interpolate_years: bool = Field(
+        default=True,
+        description="If True, the hazard model interpolates the available years to provide data for the requested years. ",
+    )
     hazard_scope_by_indicator: Optional[Dict[str, List[str] | None]] = Field(
         default=None,
         description="Dictionary of hazards and corresponding indicator ids to include in analysis.",

--- a/src/physrisk/requests.py
+++ b/src/physrisk/requests.py
@@ -178,6 +178,7 @@ class Requester:
         hazard_model = self.hazard_model_factory.hazard_model(
             interpolation=request.interpolation,
             provider_max_requests=request.provider_max_requests,
+            interpolate_years=request.interpolate_years,
         )
         return _get_hazard_data(
             request, hazard_model=hazard_model, sig_figures=self.round_sig_figures
@@ -198,6 +199,7 @@ class Requester:
         hazard_model = self.hazard_model_factory.hazard_model(
             interpolation=request.calc_settings.hazard_interp,
             provider_max_requests=request.provider_max_requests,
+            interpolate_years=request.calc_settings.interpolate_years,
         )
         return _get_asset_exposures(
             request, hazard_model, asset_factory=self.asset_factory
@@ -207,6 +209,7 @@ class Requester:
         hazard_model = self.hazard_model_factory.hazard_model(
             interpolation=request.calc_settings.hazard_interp,
             provider_max_requests=request.provider_max_requests,
+            interpolate_years=request.calc_settings.interpolate_years,
         )
 
         if (


### PR DESCRIPTION

We've added the interpolate_years parameter to CalcSettings and HazardDataRequest to allow for configuration.

The hazard_model() method of the HazardModelFactory protocol allows passing interpolate_years as an argument, akin to how the vulnerability_models() method of the VulnerabilityModelsFactory protocol allows passing hazard_scope as an argument. 
When the requester calls the factory to instantiate the models, it can forward those parameters from the request dict. This was true previously for vulnerability models, and with our changes, it can now also be done for the hazard model and the interpolate_years parameter. 

 
Co-authored-by: Juan Román Roche [jroman@arfimaconsulting.com](mailto:jroman@arfimaconsulting.com)
Co-authored-by: Violeta Crespo Cobas [vcrespo@arfima.com](mailto:vcrespo@arfima.com)
Co-authored-by: Arfima Dev [dev@arfima.com](mailto:dev@arfima.com)
Signed-off-by:  Violeta Crespo Cobas [vcrespo@arfima.com](mailto:vcrespo@arfima.com)