### PR TITLE
Add a new requester endpoint get_available_sources

### DIFF
--- a/src/physrisk/api/v1/availability_sources.py
+++ b/src/physrisk/api/v1/availability_sources.py
@@ -1,0 +1,36 @@
+from typing import Dict, List
+from pydantic import BaseModel, Field
+from physrisk.api.v1.hazard_data import Scenario
+
+
+class AvailabilitySourcesRequest(BaseModel):
+    """Hazard data availability request"""
+
+    include_all: bool = Field(
+        False,
+        description="If true, brings back all available information about years and scenarios per each hazard",
+    )
+    use_case_id: str = Field(
+        "DEFAULT",
+        description="Use case id determines which set of hazards will be taken into account depending on the selected vulnerability models",
+    )
+    selected_hazards_list: list[str] = Field(
+        [], description="Specify which list of hazards the data is required for"
+    )
+
+
+class HazardTypeAvailability(BaseModel):
+    scenarios: List[Scenario] = []
+    available_for_assets_type: List[str] = []
+    indicator_display_name: str = ""
+
+
+class AvailabilitySourcesResponse(BaseModel):
+    hazards: Dict[str, Dict[str, HazardTypeAvailability]] = Field(
+        {},
+        description="Information of available sources for the hazards in the inventory",
+    )
+    message: str = Field(
+        "",
+        description="Aditional information related to the obtained available sources",
+    )

--- a/src/physrisk/container.py
+++ b/src/physrisk/container.py
@@ -134,6 +134,7 @@ class Container(containers.DeclarativeContainer):
         hazard_model_factory=hazard_model_factory,
         vulnerability_models_factory=vulnerability_models_factory,
         inventory=inventory,
+        source_paths=source_paths,
         inventory_reader=inventory_reader,
         reader=zarr_reader,
         colormaps=colormaps,

--- a/src/physrisk/hazard_models/core_hazards.py
+++ b/src/physrisk/hazard_models/core_hazards.py
@@ -1,6 +1,8 @@
 from enum import Enum
-from pathlib import PurePosixPath
 from typing import Dict, Iterable, List, NamedTuple, Optional, Protocol, Sequence, Type
+import re
+from collections import defaultdict
+from pathlib import PurePosixPath
 
 from physrisk.api.v1.hazard_data import HazardResource
 from physrisk.data.hazard_data_provider import (
@@ -18,6 +20,7 @@ from physrisk.kernel.hazards import (
     Hazard,
     RiverineInundation,
     Wind,
+    hazard_class,
 )
 
 
@@ -29,7 +32,7 @@ class ResourceSubset:
         return any(self.resources)
 
     def first(self):
-        return [next(r for r in self.resources)]
+        return [self.resources[0]]
 
     def match(self, hint: HazardDataHint):
         return [next(r for r in self.resources if r.path == hint.path)]
@@ -48,6 +51,14 @@ class ResourceSubset:
         return ResourceSubset(
             r for r in self.resources if r.indicator_model_id == model_id
         )
+
+    def with_display_name(self, display_name: str):
+        return ResourceSubset(
+            r for r in self.resources if r.display_name == display_name
+        )
+
+    def last(self):
+        return [self.resources[-1]]
 
 
 class ResourceSelector(Protocol):
@@ -76,6 +87,9 @@ class InventorySourcePaths(SourcePaths):
     def __init__(self, inventory: Inventory):
         self._inventory = inventory
         self._selectors: Dict[ResourceSelectorKey, ResourceSelector] = {}
+        self._all_selected_resources_by_type_id: (
+            defaultdict[tuple[str, str], list[HazardResource]] | None
+        ) = None
 
     def add_selector(
         self, hazard_type: type, indicator_id: str, selector: ResourceSelector
@@ -230,6 +244,28 @@ class InventorySourcePaths(SourcePaths):
     ):
         return candidates.first()
 
+    @property
+    def all_selected_resources_by_type_id(
+        self,
+    ) -> dict[tuple[str, str], list[HazardResource]]:
+        if self._all_selected_resources_by_type_id is None:
+            self._all_selected_resources_by_type_id = defaultdict(list)
+
+            for (
+                hazard,
+                indicator_id,
+            ), _ in self._inventory.resources_by_type_id.items():
+                hazard_type = hazard_class(hazard)
+                if hazard_type is None:
+                    continue
+
+                selected = self.get_resources(
+                    hazard_type=hazard_type, indicator_id=indicator_id, hint=None
+                )
+                self._all_selected_resources_by_type_id[hazard, indicator_id] = selected
+
+        return self._all_selected_resources_by_type_id
+
 
 class CoreFloodModels(Enum):
     WRI = 1
@@ -330,14 +366,25 @@ def cmip6_scenario_to_rcp(scenario: str):
     RCP-4.5: 'rcp4p5'
     RCP-8.5: 'rcp8p5' etc.
     """
-    if scenario == "ssp126":
-        return "rcp2p6"
-    elif scenario == "ssp245":
-        return "rcp4p5"
-    elif scenario == "ssp585":
-        return "rcp8p5"
+    match = re.fullmatch(r"ssp([1-5])(\d)(\d)", scenario)
+    if match:
+        first, second, third = match.groups()
+        return f"rcp{second}p{third}"
     else:
-        if scenario not in ["rcp2p6", "rcp4p5", "rcp6p0", "rcp8p5", "historical"]:
+        # Handle scenarios that do not match the SSP pattern but are valid RCPs or historical
+        valid_scenarios = [
+            "rcp2p6",
+            "rcp4p5",
+            "rcp6p0",
+            "rcp8p5",
+            "historical",
+            "rcp26",
+            "rcp45",
+            "rcp60",
+            "rcp7p0",
+            "rcp85",
+        ]
+        if scenario not in valid_scenarios:
             raise ValueError(f"unexpected scenario {scenario}")
         return scenario
 

--- a/src/physrisk/hazard_models/core_hazards.py
+++ b/src/physrisk/hazard_models/core_hazards.py
@@ -256,8 +256,6 @@ class InventorySourcePaths(SourcePaths):
                 indicator_id,
             ), _ in self._inventory.resources_by_type_id.items():
                 hazard_type = hazard_class(hazard)
-                if hazard_type is None:
-                    continue
 
                 selected = self.get_resources(
                     hazard_type=hazard_type, indicator_id=indicator_id, hint=None

--- a/src/physrisk/requests.py
+++ b/src/physrisk/requests.py
@@ -39,7 +39,10 @@ from physrisk.data.inventory import expand
 from physrisk.data.inventory_reader import InventoryReader
 from physrisk.data.static.scenarios import scenario_description
 from physrisk.data.zarr_reader import ZarrReader
-from physrisk.hazard_models.core_hazards import get_default_source_paths
+from physrisk.hazard_models.core_hazards import (
+    InventorySourcePaths,
+    get_default_source_paths,
+)
 from physrisk.kernel.exposure import JupterExposureMeasure, calculate_exposures
 from physrisk.kernel.hazards import Hazard, hazard_class
 from physrisk.kernel.impact import AssetImpactResult, ImpactKey  # , ImpactKey
@@ -96,8 +99,13 @@ from .api.v1.impact_req_resp import (
     ScoreBasedRiskMeasureDefinition,
     ScoreBasedRiskMeasureSetDefinition,
 )
+from physrisk.api.v1.availability_sources import (
+    AvailabilitySourcesRequest,
+    AvailabilitySourcesResponse,
+    HazardTypeAvailability,
+)
 from .data.inventory import EmbeddedInventory, Inventory
-from .kernel.assets import Asset
+from physrisk.kernel.assets import Asset, all_asset_types
 from .kernel import calculation as calc
 from .kernel.hazard_model import (
     HazardDataRequest as hmHazardDataRequest,
@@ -121,6 +129,7 @@ class Requester:
         hazard_model_factory: HazardModelFactory,
         vulnerability_models_factory: VulnerabilityModelsFactory,
         inventory: Inventory,
+        source_paths: InventorySourcePaths,
         inventory_reader: InventoryReader,
         reader: ZarrReader,
         colormaps: Colormaps,
@@ -138,6 +147,7 @@ class Requester:
         self.inventory = inventory
         self.inventory_reader = inventory_reader
         self.zarr_reader = reader
+        self.source_paths = source_paths
 
     def get(self, *, request_id, request_dict):
         if request_id == "get_hazard_data":
@@ -165,6 +175,9 @@ class Requester:
             )
         elif request_id == "get_example_portfolios":
             return self.dumps(self.get_example_portfolios())
+        elif request_id == "get_available_sources":
+            request = AvailabilitySourcesRequest(**request_dict)
+            return self.dumps(self.get_available_sources(request).model_dump())
         elif request_id == "get_image_info":
             request = HazardImageInfoRequest(**request_dict)
             return self.dumps(self.get_image_info(request).model_dump())
@@ -204,6 +217,43 @@ class Requester:
         return _get_asset_exposures(
             request, hazard_model, asset_factory=self.asset_factory
         )
+
+    def get_available_sources(
+        self, request: AvailabilitySourcesRequest
+    ) -> AvailabilitySourcesResponse:
+        resources = [
+            resource
+            for resources in self.source_paths.all_selected_resources_by_type_id.values()
+            for resource in resources
+        ]
+
+        if request.selected_hazards_list:
+            resources = [
+                s for s in resources if s.hazard_type in request.selected_hazards_list
+            ]
+        result = _create_available_sources_result(
+            resources=resources,
+        )
+
+        if not request.include_all:
+            vulnerability_models = (
+                self.vulnerability_models_factory.vulnerability_models()
+            )
+            result = _filter_with_vuln_models(
+                result=result,
+                vulnerability_models=vulnerability_models,
+            )
+
+        message = ""
+        if not result:
+            message = (
+                f"Empty for the combination of the following request parameters:\n"
+                f"include_all={request.include_all},\n"
+                f"USE_CASE_ID={request.use_case_id},\n"
+                f"selected_hazard_list={request.selected_hazards_list}"
+            )
+
+        return AvailabilitySourcesResponse(hazards=result, message=message)
 
     def get_asset_impacts(self, request: AssetImpactRequest) -> AssetImpactResponse:
         hazard_model = self.hazard_model_factory.hazard_model(
@@ -840,6 +890,66 @@ def _get_example_portfolios() -> dict[str, Assets]:
             portfolio = Assets(**json.load(f))
             portfolios[file.name.replace(".json", "")] = portfolio
     return portfolios
+
+
+def _create_available_sources_result(
+    resources: list[HazardResource],
+) -> dict[str, dict[str, HazardTypeAvailability]]:
+    result: dict[str, dict[str, HazardTypeAvailability]] = {}
+    for resource in resources:
+        availability = result.setdefault(resource.hazard_type, {}).setdefault(
+            resource.indicator_id,
+            HazardTypeAvailability(),
+        )
+        availability.scenarios.extend(resource.scenarios)
+        availability.indicator_display_name = resource.display_name
+
+    return result
+
+
+def _filter_with_vuln_models(
+    result: dict[str, dict[str, HazardTypeAvailability]],
+    vulnerability_models: VulnerabilityModels,
+) -> dict[str, dict[str, HazardTypeAvailability]]:
+    filtered_result: dict[str, dict[str, HazardTypeAvailability]] = {}
+
+    for asset_type in all_asset_types():
+        asset_type_name = asset_type.__name__
+
+        allowed = _get_hazards_from_vulnerability_models(
+            vulnerability_models, asset_type
+        )
+
+        for hazard_type, indicators in result.items():
+            allowed_indicators = allowed.get(hazard_type)
+            if not allowed_indicators:
+                continue
+
+            target = filtered_result.setdefault(hazard_type, {})
+
+            for indicator, availability in indicators.items():
+                if indicator not in allowed_indicators:
+                    continue
+
+                target[indicator] = availability
+
+                if asset_type_name not in availability.available_for_assets_type:
+                    availability.available_for_assets_type.append(asset_type_name)
+
+    return filtered_result
+
+
+def _get_hazards_from_vulnerability_models(
+    vulnerability_models: VulnerabilityModels,
+    asset_type: type[Asset],
+) -> dict[str, list[str]]:
+    hazards: dict[str, list[str]] = {}
+    for vuln_model in vulnerability_models.vuln_model_for_asset_of_type(asset_type):
+        hazard_name = vuln_model.hazard_type.__name__
+        hazards.setdefault(hazard_name, [])
+        hazards[hazard_name].append(vuln_model.indicator_id)
+
+    return hazards
 
 
 def _hazard_type_indicators(measures: dict[MeasureKey, Measure]):

--- a/tests/kernel/test_exposure.py
+++ b/tests/kernel/test_exposure.py
@@ -46,6 +46,7 @@ class TestExposureMeasures(TestWithCredentials):
             hazard_model_factory=hazard_model_factory,
             vulnerability_models_factory=None,
             inventory=inventory,
+            source_paths=get_default_source_paths(inventory),
             inventory_reader=InventoryReader(fs=local.LocalFileSystem(), base_path=""),
             reader=ZarrReader(store=store),
             colormaps=inventory.colormaps(),


### PR DESCRIPTION
This new endpoint is designed to allow the user to first gather information about the available data sources before making an "actual" request. This endpoint is a bit less raw than e.g. get_hazard_data_availability, since it already includes only those sources that would be selected by the selectors in the InventorySourcePaths object. It also allows filtering with the vulnerability models that would be used in an impact request, returning only those sources which provide data that can later be processed by the vulnerability model.

In summary, it tells the user "if you make an impact request with this combination of hazards, hazard indicators, scenarios, years and asset types the requester should be able to fulfill it".

Co-authored-by: Yulian Lyubomirov Cenov [ycenov@arfima.com](mailto:ycenov@arfima.com)
Co-authored-by: Juan Román Roche [jroman@arfimaconsulting.com](mailto:jroman@arfimaconsulting.com)
Co-authored-by: Violeta Crespo Cobas [vcrespo@arfima.com](mailto:vcrespo@arfima.com)
Co-authored-by: Arfima Dev [dev@arfima.com](mailto:dev@arfima.com)
Signed-off-by: Yulian Lyubomirov Cenov [ycenov@arfima.com](mailto:ycenov@arfima.com)