### PR TITLE
Add protective code to catch and fix two extrapolation error cases

### DIFF
--- a/src/physrisk/data/pregenerated_hazard_model.py
+++ b/src/physrisk/data/pregenerated_hazard_model.py
@@ -87,6 +87,9 @@ class PregeneratedHazardModel(HazardModel):
                     or (hazard_type == Hail and indicator_id == "days/above/5cm")
                     or (hazard_type == Fire and indicator_id == "fire_probability")
                 )
+                # Add check that indicators are non-negative. This can occur in cases
+                # of extrapolation, even if underlying hazard data is well-behaved.
+                non_negative = nan_is_zero
                 for req in batch:
                     lat_lon_index.setdefault(
                         (req.latitude, req.longitude, req.buffer), len(lat_lon_index)
@@ -172,6 +175,8 @@ class PregeneratedHazardModel(HazardModel):
                             else:
                                 if nan_is_zero:
                                     values[np.isnan(values)] = 0.0
+                                if non_negative:
+                                    values[values < 0] = 0.0
                                 responses[req] = HazardParameterDataResponse(
                                     values.astype(dtype="float64"),
                                     indices,

--- a/src/physrisk/vulnerability_models/config_based_vuln_model_acute.py
+++ b/src/physrisk/vulnerability_models/config_based_vuln_model_acute.py
@@ -1,4 +1,5 @@
 from enum import Enum
+import logging
 from typing import (
     Sequence,
     Tuple,
@@ -40,6 +41,7 @@ from physrisk.vulnerability_models.impact_function_selector import (
 )
 
 ureg = UnitRegistry()
+logger = logging.getLogger(__name__)
 
 
 class StandardOfProtection(int, Enum):
@@ -135,6 +137,15 @@ class ConfigBasedVulnerabilityModelAcute(VulnerabilityModelAcuteBase):
             return EmptyVulnerabilityDistrib(), EmptyHazardEventDistrib()
 
         fut_intensities = future.intensities
+        # Ensure that the curve does not decrease. A decreasing curve will not generally occur, assuming that
+        # the hazard data is well-behaved. However, extrapolation of monotonic curves can (mathematically) give
+        # rise to a non-monotonic curve. Note that this can only occur for extrapolation, not interpolation.
+        if not np.all(np.diff(fut_intensities) >= 0):
+            fut_intensities = np.maximum.accumulate(fut_intensities)
+            logging.warning(
+                "Future hazard curve is not monotonic; adjusting to ensure non-decreasing curve."
+            )
+
         conversion = curve.indicator_units is not None and future.units != "default"
         if conversion:
             fut_intensities = ureg.convert(


### PR DESCRIPTION
In the case of (e.g. linear) extrapolation of hazard indicator data over time, values can occur that will give rise to downstream errors:
1) curves that must be monotonic extrapolated to a non-monotonic curve
2) data that must be non-negative (e.g. probabilities) interpolated to negative values
Protective code is put in place for these cases; to enforce non-decreasing and positive probabilities respectively.
Note that this only occurs for extrapolation, not interpolation.