### PR TITLE
Translate API request tests to pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,9 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
+markers = [
+    "live_data: tests that hit live/external data sources",
+]
 testpaths = ["tests",
 ]
 addopts = "-v --update_expected=False --update_inputs=False"

--- a/tests/api/test_data_requests.py
+++ b/tests/api/test_data_requests.py
@@ -1,20 +1,17 @@
+import pytest
 import json
-import unittest
-
 import numpy as np
-import numpy.testing
 
-from physrisk import requests
-from physrisk.container import Container
 from physrisk.data.hazard_data_provider import HazardDataHint
 from physrisk.data.inventory import EmbeddedInventory
 from physrisk.data.pregenerated_hazard_model import ZarrHazardModel
 from physrisk.data.zarr_reader import ZarrReader
 from physrisk.hazard_models.core_hazards import get_default_source_paths
 from physrisk.kernel.hazards import ChronicHeat, RiverineInundation
+from physrisk.container import Container
+from physrisk import requests
 
-from ..api.test_container import TestContainer
-from ..test_base import TestWithCredentials
+from .test_container import TestContainer
 from ..data.test_hazard_model_store import (
     TestData,
     get_mock_hazard_model_store_single_curve,
@@ -22,245 +19,224 @@ from ..data.test_hazard_model_store import (
 )
 
 
-class TestDataRequests(TestWithCredentials):
-    def setUp(self):
-        super().setUp()
+def test_hazard_data_availability():
+    # test that validation passes:
+    container = Container()
+    container.override(TestContainer())
+    requester = container.requester()
+    _ = requester.get(request_id="get_hazard_data_availability", request_dict={})
 
-    def tearDown(self):
-        super().tearDown()
 
-    def test_hazard_data_availability(self):
-        # test that validation passes:
-        container = Container()
-        container.override(TestContainer())
-        requester = container.requester()
-        _ = requester.get(request_id="get_hazard_data_availability", request_dict={})
+@pytest.mark.live_data("dev")
+def test_hazard_data_description(clear_credentials):
+    # test that validation passes:
+    container = Container()
+    requester = container.requester()
+    _ = requester.get(
+        request_id="get_hazard_data_description",
+        request_dict={"paths": ["test_path.md"]},
+    )
 
-    @unittest.skip("requires mocking.")
-    def test_hazard_data_description(self):
-        # test that validation passes:
-        container = Container()
-        requester = container.requester
-        _ = requester.get(
-            request_id="get_hazard_data_description",
-            request_dict={"paths": ["test_path.md"]},
-        )
 
-    def test_generic_source_path(self):
-        inventory = EmbeddedInventory()
-        source_paths = get_default_source_paths(inventory)
-        result_heat = (
-            source_paths.resource_paths(
-                ChronicHeat,
-                indicator_id="mean_degree_days/above/32c",
-                scenarios=["ssp585"],
-            )[0]
-            .scenarios["ssp585"]
-            .path(2050)
-        )
-        result_flood = (
-            source_paths.resource_paths(
-                RiverineInundation, indicator_id="flood_depth", scenarios=["ssp585"]
-            )[0]
-            .scenarios["ssp585"]
-            .path(2050)
-        )
-        result_flood_hist = (
-            source_paths.resource_paths(
-                RiverineInundation, indicator_id="flood_depth", scenarios=["historical"]
-            )[0]
-            .scenarios["historical"]
-            .path(2080)
-        )
-        result_heat_hint = (
-            source_paths.resource_paths(
-                ChronicHeat,
-                indicator_id="mean_degree_days/above/32c",
-                scenarios=["ssp585"],
-                hint=HazardDataHint(
-                    path="chronic_heat/osc/v2/mean_degree_days_v2_above_32c_CMCC-ESM2_{scenario}_{year}"
-                ),
-            )[0]
-            .scenarios["ssp585"]
-            .path(2050)
-        )
+@pytest.mark.live_data("dev")
+def test_available_sources(clear_credentials):
+    # test that validation passes:
+    container = Container()
+    requester = container.requester()
+    resp = requester.get(request_id="get_available_sources", request_dict={})
+    # Uncomment the following lines to save the response to a file for debugging
+    # with open("available_sources.json", "w") as f:
+    #     f.write(resp)
+    assert resp != "[]"
 
-        assert (
-            result_heat
-            == "chronic_heat/osc/v2/mean_degree_days_v2_above_32c_ACCESS-CM2_ssp585_2050"
-        )
-        assert result_flood == "inundation/wri/v2/inunriver_rcp8p5_MIROC-ESM-CHEM_2050"
-        assert (
-            result_flood_hist
-            == "inundation/wri/v2/inunriver_rcp4p5_MIROC-ESM-CHEM_2030"
-        )
-        assert (
-            result_heat_hint
-            == "chronic_heat/osc/v2/mean_degree_days_v2_above_32c_CMCC-ESM2_ssp585_2050"
-        )
 
-    def test_zarr_reading(self):
-        request_dict = {
-            "items": [
-                {
-                    "request_item_id": "test_inundation",
-                    "event_type": "RiverineInundation",
-                    "longitudes": TestData.longitudes[
-                        0:3
-                    ],  # coords['longitudes'][0:100],
-                    "latitudes": TestData.latitudes[0:3],  # coords['latitudes'][0:100],
-                    "year": 2080,
-                    "scenario": "rcp8p5",
-                    "indicator_id": "flood_depth",
-                    "indicator_model_gcm": "MIROC-ESM-CHEM",
-                }
-            ],
-        }
-        # validate request
-        request = requests.HazardDataRequest(**request_dict)  # type: ignore
-
-        store = get_mock_hazard_model_store_single_curve()
-
-        result = requests._get_hazard_data(
-            request,
-            ZarrHazardModel(
-                source_paths=get_default_source_paths(EmbeddedInventory()),
-                reader=ZarrReader(store=store),
+def test_generic_source_path():
+    inventory = EmbeddedInventory()
+    source_paths = get_default_source_paths(inventory)
+    result_heat = (
+        source_paths.resource_paths(
+            ChronicHeat,
+            indicator_id="mean_degree_days/above/32c",
+            scenarios=["ssp585"],
+        )[0]
+        .scenarios["ssp585"]
+        .path(2050)
+    )
+    result_flood = (
+        source_paths.resource_paths(
+            RiverineInundation, indicator_id="flood_depth", scenarios=["ssp585"]
+        )[0]
+        .scenarios["ssp585"]
+        .path(2050)
+    )
+    result_flood_hist = (
+        source_paths.resource_paths(
+            RiverineInundation, indicator_id="flood_depth", scenarios=["historical"]
+        )[0]
+        .scenarios["historical"]
+        .path(2080)
+    )
+    result_heat_hint = (
+        source_paths.resource_paths(
+            ChronicHeat,
+            indicator_id="mean_degree_days/above/32c",
+            scenarios=["ssp585"],
+            hint=HazardDataHint(
+                path="chronic_heat/osc/v2/mean_degree_days_v2_above_32c_CMCC-ESM2_{scenario}_{year}"
             ),
-        )
+        )[0]
+        .scenarios["ssp585"]
+        .path(2050)
+    )
 
-        numpy.testing.assert_array_almost_equal_nulp(
-            result.items[0].intensity_curve_set[0].intensities, np.zeros((9))
-        )
-        numpy.testing.assert_array_almost_equal_nulp(
-            result.items[0].intensity_curve_set[1].intensities,
-            np.linspace(0.1, 1.0, 9, dtype="f4"),
-        )
-        numpy.testing.assert_array_almost_equal_nulp(
-            result.items[0].intensity_curve_set[2].intensities, np.zeros((9))
-        )
+    assert (
+        result_heat
+        == "chronic_heat/osc/v2/mean_degree_days_v2_above_32c_ACCESS-CM2_ssp585_2050"
+    )
+    assert result_flood == "inundation/wri/v2/inunriver_rcp8p5_MIROC-ESM-CHEM_2050"
+    assert result_flood_hist == "inundation/wri/v2/inunriver_rcp4p5_MIROC-ESM-CHEM_2030"
+    assert (
+        result_heat_hint
+        == "chronic_heat/osc/v2/mean_degree_days_v2_above_32c_CMCC-ESM2_ssp585_2050"
+    )
 
-    def test_zarr_reading_chronic(self):
-        request_dict = {
-            "group_ids": ["osc"],
-            "items": [
-                {
-                    "request_item_id": "test_inundation",
-                    "event_type": "ChronicHeat",
-                    "longitudes": TestData.longitudes[
-                        0:3
-                    ],  # coords['longitudes'][0:100],
-                    "latitudes": TestData.latitudes[0:3],  # coords['latitudes'][0:100],
-                    "year": 2050,
-                    "scenario": "ssp585",
-                    "indicator_id": "mean_degree_days/above/32c",
-                }
-            ],
-        }
-        # validate request
-        request = requests.HazardDataRequest(**request_dict)  # type: ignore
 
-        store = mock_hazard_model_store_heat(TestData.longitudes, TestData.latitudes)
+def test_zarr_reading():
+    request_dict = {
+        "items": [
+            {
+                "request_item_id": "test_inundation",
+                "event_type": "RiverineInundation",
+                "longitudes": TestData.longitudes[0:3],  # coords['longitudes'][0:100],
+                "latitudes": TestData.latitudes[0:3],  # coords['latitudes'][0:100],
+                "year": 2080,
+                "scenario": "rcp8p5",
+                "indicator_id": "flood_depth",
+                "indicator_model_gcm": "MIROC-ESM-CHEM",
+            }
+        ],
+    }
+    # validate request
+    request = requests.HazardDataRequest(**request_dict)  # type: ignore
 
-        source_paths = get_default_source_paths(EmbeddedInventory())
-        result = requests._get_hazard_data(
-            request,
-            ZarrHazardModel(source_paths=source_paths, reader=ZarrReader(store)),
-        )
-        numpy.testing.assert_array_almost_equal_nulp(
-            result.items[0].intensity_curve_set[0].intensities[0], 600.0
-        )
+    store = get_mock_hazard_model_store_single_curve()
 
-        # request_with_hint = request.copy()
-        # request_with_hint.items[0].path = "chronic_heat/osc/v2/mean_degree_days_v2_above_32c_CMCC-ESM2_rcp8p5_2050"
-        # result = requests._get_hazard_data(
-        #    request_with_hint, ZarrHazardModel(source_paths=source_paths, reader=ZarrReader(store))
-        # )
+    result = requests._get_hazard_data(
+        request,
+        ZarrHazardModel(
+            source_paths=get_default_source_paths(EmbeddedInventory()),
+            reader=ZarrReader(store=store),
+        ),
+    )
 
-    @unittest.skip("requires OSC environment variables set")
-    def test_zarr_reading_live(self):
-        # needs valid OSC_S3_BUCKET, OSC_S3_ACCESS_KEY, OSC_S3_SECRET_KEY
-        container = Container()
-        requester = container.requester()
+    np.testing.assert_array_almost_equal_nulp(
+        result.items[0].intensity_curve_set[0].intensities, np.zeros((9))
+    )
+    np.testing.assert_array_almost_equal_nulp(
+        result.items[0].intensity_curve_set[1].intensities,
+        np.linspace(0.1, 1.0, 9, dtype="f4"),
+    )
+    np.testing.assert_array_almost_equal_nulp(
+        result.items[0].intensity_curve_set[2].intensities, np.zeros((9))
+    )
 
-        import json
-        from zipfile import ZipFile
 
-        with ZipFile("src/test/api/test_lat_lons.json.zip") as z:
-            with z.open("test_lat_lons.json") as f:
-                data = json.loads(f.read())
+def test_zarr_reading_chronic():
+    request_dict = {
+        "group_ids": ["osc"],
+        "items": [
+            {
+                "request_item_id": "test_inundation",
+                "event_type": "ChronicHeat",
+                "longitudes": TestData.longitudes[0:3],  # coords['longitudes'][0:100],
+                "latitudes": TestData.latitudes[0:3],  # coords['latitudes'][0:100],
+                "year": 2050,
+                "scenario": "ssp585",
+                "indicator_id": "mean_degree_days/above/32c",
+            }
+        ],
+    }
+    # validate request
+    request = requests.HazardDataRequest(**request_dict)  # type: ignore
 
-        request1 = {
-            "items": [
-                {
-                    "request_item_id": "test_inundation",
-                    "event_type": "ChronicHeat",
-                    "longitudes": TestData.longitudes,
-                    "latitudes": TestData.latitudes,
-                    "year": 2030,
-                    "scenario": "ssp585",
-                    "indicator_id": "mean_work_loss/high",
-                }
-            ],
-        }
+    store = mock_hazard_model_store_heat(TestData.longitudes, TestData.latitudes)
 
-        request1 = {
-            "items": [
-                {
-                    "request_item_id": "test_inundation",
-                    "event_type": "ChronicHeat",
-                    "longitudes": data["longitudes"],
-                    "latitudes": data["latitudes"],
-                    "year": 2030,
-                    "scenario": "ssp585",
-                    "indicator_id": "mean_work_loss/high",
-                }
-            ],
-        }
+    source_paths = get_default_source_paths(EmbeddedInventory())
+    result = requests._get_hazard_data(
+        request,
+        ZarrHazardModel(source_paths=source_paths, reader=ZarrReader(store)),
+    )
+    np.testing.assert_array_almost_equal_nulp(
+        result.items[0].intensity_curve_set[0].intensities[0], 600.0
+    )
 
-        response_floor = requester.get(
-            request_id="get_hazard_data", request_dict=request1
-        )
-        request1["interpolation"] = "linear"  # type: ignore
-        response_linear = requester.get(
-            request_id="get_hazard_data", request_dict=request1
-        )
-        print(response_linear)
 
-        floor = json.loads(response_floor)["items"][0]["intensity_curve_set"][5][
-            "intensities"
-        ]
-        linear = json.loads(response_linear)["items"][0]["intensity_curve_set"][5][
-            "intensities"
-        ]
+@pytest.mark.live_data("dev")
+def test_zarr_reading_live(clear_credentials):
+    # needs valid OSC_S3_BUCKET, OSC_S3_ACCESS_KEY, OSC_S3_SECRET_KEY
+    container = Container()
+    requester = container.requester()
 
-        print(floor)
-        print(linear)
+    import json
+    from zipfile import ZipFile
 
-        request2 = {
-            "items": [
-                {
-                    "request_item_id": "test_inundation",
-                    "event_type": "CoastalInundation",
-                    "longitudes": TestData.coastal_longitudes,
-                    "latitudes": TestData.coastal_latitudes,
-                    "year": 2080,
-                    "scenario": "rcp8p5",
-                    "model": "wtsub/95",
-                }
-            ],
-        }
-        response = requester.get(request_type="get_hazard_data", request_dict=request2)
-        print(response)
+    with ZipFile("./tests/api/test_lat_lons.json.zip") as z:
+        with z.open("test_lat_lons.json") as f:
+            data = json.loads(f.read())
 
-    def test_static_information(self):
-        container = Container()
-        container.override_providers(inventory_reader=None)
-        container.override_providers(zarr_reader=None)
-        requester = container.requester()
-        static_info = requester.get(
-            request_id="get_static_information", request_dict=None
-        )
-        assert json.loads(static_info)["scenario_descriptions"]["ssp585"].startswith(
-            "The SSP585 scenario"
-        )
+    request1 = {
+        "items": [
+            {
+                "request_item_id": "test_inundation",
+                "event_type": "ChronicHeat",
+                "longitudes": data["longitudes"],
+                "latitudes": data["latitudes"],
+                "year": 2030,
+                "scenario": "ssp585",
+                "indicator_id": "mean_work_loss/high",
+            }
+        ],
+    }
+
+    response_floor = requester.get(request_id="get_hazard_data", request_dict=request1)
+    request1["interpolation"] = "linear"  # type: ignore
+    response_linear = requester.get(request_id="get_hazard_data", request_dict=request1)
+    print(response_linear)
+
+    floor = json.loads(response_floor)["items"][0]["intensity_curve_set"][5][
+        "intensities"
+    ]
+    linear = json.loads(response_linear)["items"][0]["intensity_curve_set"][5][
+        "intensities"
+    ]
+
+    print(floor)
+    print(linear)
+
+    request2 = {
+        "items": [
+            {
+                "request_item_id": "test_inundation",
+                "event_type": "CoastalInundation",
+                "longitudes": TestData.coastal_longitudes,
+                "latitudes": TestData.coastal_latitudes,
+                "year": 2080,
+                "scenario": "rcp8p5",
+                "indicator_id": "flood_depth",
+                "model_id": "wtsub/95",
+            }
+        ],
+    }
+    response = requester.get(request_id="get_hazard_data", request_dict=request2)
+    print(response)
+
+
+def test_static_information():
+    container = Container()
+    container.override_providers(inventory_reader=None)
+    container.override_providers(zarr_reader=None)
+    requester = container.requester()
+    static_info = requester.get(request_id="get_static_information", request_dict=None)
+    assert json.loads(static_info)["scenario_descriptions"]["ssp585"].startswith(
+        "The SSP585 scenario"
+    )

--- a/tests/api/test_impact_requests.py
+++ b/tests/api/test_impact_requests.py
@@ -1,9 +1,11 @@
+import os
 import json
-
 import numpy as np
 import pyproj
+import pytest
+from pydantic import TypeAdapter
 import shapely
-
+import logging
 from physrisk import requests
 from physrisk.api.v1.common import Asset, Assets
 from physrisk.data.inventory import EmbeddedInventory
@@ -29,8 +31,9 @@ from physrisk.vulnerability_models.thermal_power_generation_models import (
     ThermalPowerGenerationWaterStressModel,
     ThermalPowerGenerationWaterTemperatureModel,
 )
+from physrisk.api.v1.impact_req_resp import RiskMeasures, RiskMeasuresHelper
+from physrisk.container import Container
 
-from ..test_base import TestWithCredentials
 from ..data.test_hazard_model_store import (
     TestData,
     add_curves,
@@ -39,752 +42,793 @@ from ..data.test_hazard_model_store import (
     zarr_memory_store,
 )
 
+logger = logging.getLogger(__name__)
 
-class TestImpactRequests(TestWithCredentials):
-    def test_asset_list_json(self):
-        assets = {
-            "items": [
-                {
-                    "asset_class": "RealEstateAsset",
-                    "type": "Buildings/Industrial",
-                    "location": "Asia",
-                    "longitude": 69.4787,
-                    "latitude": 34.556,
-                },
-                {
-                    "asset_class": "PowerGeneratingAsset",
-                    "type": "Nuclear",
-                    "location": "Asia",
-                    "longitude": -70.9157,
-                    "latitude": -39.2145,
-                },
-            ],
-        }
-        assets_obj = Assets(**assets)
-        self.assertIsNotNone(assets_obj)
 
-    def test_extra_fields(self):
-        assets = {
-            "items": [
-                {
-                    "asset_class": "RealEstateAsset",
-                    "type": "Buildings/Industrial",
-                    "location": "Asia",
-                    "longitude": 69.4787,
-                    "latitude": 34.556,
-                    "extra_field": 2.0,
-                    "capacity": 1000.0,
-                }
-            ],
-        }
-        assets = requests.create_assets(Assets(**assets))
-        # in the case of RealEstateAsset, extra fields are allowed, including those not in the Pydantic Asset object
-        assert assets[0].capacity == 1000.0
-        assert assets[0].extra_field == 2.0
-
-    def test_impact_request(self):
-        """Runs short asset-level impact request."""
-
-        assets = {
-            "items": [
-                {
-                    "asset_class": "RealEstateAsset",
-                    "type": "Buildings/Industrial",
-                    "location": "Asia",
-                    "longitude": TestData.longitudes[0],
-                    "latitude": TestData.latitudes[0],
-                },
-                {
-                    "asset_class": "PowerGeneratingAsset",
-                    "type": "Nuclear",
-                    "location": "Asia",
-                    "longitude": TestData.longitudes[1],
-                    "latitude": TestData.latitudes[1],
-                },
-            ],
-        }
-
-        request_dict = {
-            "assets": assets,
-            "include_asset_level": True,
-            "include_measures": False,
-            "include_calc_details": True,
-            "years": [2080],
-            "scenarios": ["rcp8p5"],
-        }
-
-        request = requests.AssetImpactRequest(**request_dict)  # type: ignore
-
-        curve = np.array(
-            [0.0596, 0.333, 0.505, 0.715, 0.864, 1.003, 1.149, 1.163, 1.163]
-        )
-        store = mock_hazard_model_store_inundation(
-            TestData.longitudes, TestData.latitudes, curve
-        )
-
-        source_paths = get_default_source_paths(EmbeddedInventory())
-        vulnerability_models = DictBasedVulnerabilityModels(
+def test_asset_list_json():
+    assets = {
+        "items": [
             {
-                PowerGeneratingAsset: [InundationModel()],
-                RealEstateAsset: [
-                    RealEstateCoastalInundationModel(),
-                    RealEstateRiverineInundationModel(),
-                ],
+                "asset_class": "RealEstateAsset",
+                "type": "Buildings/Industrial",
+                "location": "Asia",
+                "longitude": 69.4787,
+                "latitude": 34.556,
+            },
+            {
+                "asset_class": "PowerGeneratingAsset",
+                "type": "Nuclear",
+                "location": "Asia",
+                "longitude": -70.9157,
+                "latitude": -39.2145,
+            },
+        ],
+    }
+    assets_obj = Assets(**assets)
+    assert assets_obj is not None
+
+
+def test_extra_fields():
+    assets = {
+        "items": [
+            {
+                "asset_class": "RealEstateAsset",
+                "type": "Buildings/Industrial",
+                "location": "Asia",
+                "longitude": 69.4787,
+                "latitude": 34.556,
+                "extra_field": 2.0,
+                "capacity": 1000.0,
             }
-        )
+        ],
+    }
+    assets = requests.create_assets(Assets(**assets))
+    # in the case of RealEstateAsset, extra fields are allowed, including those not in the Pydantic Asset object
+    assert assets[0].capacity == 1000.0
+    assert assets[0].extra_field == 2.0
 
-        response = requests._get_asset_impacts(
-            request,
-            ZarrHazardModel(source_paths=source_paths, reader=ZarrReader(store)),
-            vulnerability_models=vulnerability_models,
-        )
 
-        self.assertEqual(
-            response.asset_impacts[0].impacts[0].key.hazard_type, "CoastalInundation"
-        )
+def test_impact_request():
+    """Runs short asset-level impact request."""
+    assets = {
+        "items": [
+            {
+                "asset_class": "RealEstateAsset",
+                "type": "Buildings/Industrial",
+                "location": "Asia",
+                "longitude": TestData.longitudes[0],
+                "latitude": TestData.latitudes[0],
+            },
+            {
+                "asset_class": "PowerGeneratingAsset",
+                "type": "Nuclear",
+                "location": "Asia",
+                "longitude": TestData.longitudes[1],
+                "latitude": TestData.latitudes[1],
+            },
+        ],
+    }
 
-    def test_risk_model_impact_request(self):
-        """Tests the risk model functionality of the impact request."""
+    request_dict = {
+        "assets": assets,
+        "include_asset_level": True,
+        "include_measures": False,
+        "include_calc_details": True,
+        "years": [2080],
+        "scenarios": ["rcp8p5"],
+    }
 
-        assets = {
-            "items": [
-                {
-                    "asset_class": "RealEstateAsset",
-                    "type": "Buildings/Industrial",
-                    "location": "Asia",
-                    "longitude": TestData.longitudes[0],
-                    "latitude": TestData.latitudes[0],
-                },
-                {
-                    "asset_class": "PowerGeneratingAsset",
-                    "type": "Nuclear",
-                    "location": "Asia",
-                    "longitude": TestData.longitudes[1],
-                    "latitude": TestData.latitudes[1],
-                },
+    request = requests.AssetImpactRequest(**request_dict)  # type: ignore
+
+    curve = np.array([0.0596, 0.333, 0.505, 0.715, 0.864, 1.003, 1.149, 1.163, 1.163])
+    store = mock_hazard_model_store_inundation(
+        TestData.longitudes, TestData.latitudes, curve
+    )
+
+    source_paths = get_default_source_paths(EmbeddedInventory())
+    vulnerability_models = DictBasedVulnerabilityModels(
+        {
+            PowerGeneratingAsset: [InundationModel()],
+            RealEstateAsset: [
+                RealEstateCoastalInundationModel(),
+                RealEstateRiverineInundationModel(),
             ],
         }
+    )
 
-        request_dict = {
-            "assets": assets,
-            "include_asset_level": True,
-            "include_measures": False,
-            "include_calc_details": True,
-            "years": [2080],
-            "scenarios": ["rcp8p5"],
-        }
+    response = requests._get_asset_impacts(
+        request,
+        ZarrHazardModel(source_paths=source_paths, reader=ZarrReader(store)),
+        vulnerability_models=vulnerability_models,
+    )
 
-        request = requests.AssetImpactRequest(**request_dict)  # type: ignore
+    assert response.asset_impacts[0].impacts[0].key.hazard_type == "CoastalInundation"
 
-        curve = np.array(
-            [0.0596, 0.333, 0.505, 0.715, 0.864, 1.003, 1.149, 1.163, 1.163]
-        )
-        store = mock_hazard_model_store_inundation(
-            TestData.longitudes, TestData.latitudes, curve
-        )
 
-        source_paths = get_default_source_paths(EmbeddedInventory())
-        vulnerability_models = DictBasedVulnerabilityModels(
+def test_risk_model_impact_request():
+    """Tests the risk model functionality of the impact request."""
+
+    assets = {
+        "items": [
             {
-                PowerGeneratingAsset: [InundationModel()],
-                RealEstateAsset: [
-                    RealEstateCoastalInundationModel(),
-                    RealEstateRiverineInundationModel(),
-                ],
-            }
+                "asset_class": "RealEstateAsset",
+                "type": "Buildings/Industrial",
+                "location": "Asia",
+                "longitude": TestData.longitudes[0],
+                "latitude": TestData.latitudes[0],
+            },
+            {
+                "asset_class": "PowerGeneratingAsset",
+                "type": "Nuclear",
+                "location": "Asia",
+                "longitude": TestData.longitudes[1],
+                "latitude": TestData.latitudes[1],
+            },
+        ],
+    }
+
+    request_dict = {
+        "assets": assets,
+        "include_asset_level": True,
+        "include_measures": False,
+        "include_calc_details": True,
+        "years": [2080],
+        "scenarios": ["rcp8p5"],
+    }
+
+    request = requests.AssetImpactRequest(**request_dict)  # type: ignore
+
+    curve = np.array([0.0596, 0.333, 0.505, 0.715, 0.864, 1.003, 1.149, 1.163, 1.163])
+    store = mock_hazard_model_store_inundation(
+        TestData.longitudes, TestData.latitudes, curve
+    )
+
+    source_paths = get_default_source_paths(EmbeddedInventory())
+    vulnerability_models = DictBasedVulnerabilityModels(
+        {
+            PowerGeneratingAsset: [InundationModel()],
+            RealEstateAsset: [
+                RealEstateCoastalInundationModel(),
+                RealEstateRiverineInundationModel(),
+            ],
+        }
+    )
+    response = requests._get_asset_impacts(
+        request,
+        ZarrHazardModel(source_paths=source_paths, reader=ZarrReader(store)),
+        vulnerability_models=vulnerability_models,
+    )
+
+    assert response.asset_impacts[0].impacts[0].key.hazard_type == "CoastalInundation"
+
+
+def test_thermal_power_generation(mocker_store):
+    latitudes = np.array([32.6017])
+    longitudes = np.array([-87.7811])
+
+    assets = [
+        ThermalPowerGeneratingAsset(
+            latitude=latitudes[0],
+            longitude=longitudes[0],
+            location="North America",
+            capacity=1288.4,
+            type=archetype,
         )
-
-        response = requests._get_asset_impacts(
-            request,
-            ZarrHazardModel(source_paths=source_paths, reader=ZarrReader(store)),
-            vulnerability_models=vulnerability_models,
-        )
-
-        self.assertEqual(
-            response.asset_impacts[0].impacts[0].key.hazard_type, "CoastalInundation"
-        )
-
-    def test_thermal_power_generation(self):
-        latitudes = np.array([32.6017])
-        longitudes = np.array([-87.7811])
-
-        assets = [
-            ThermalPowerGeneratingAsset(
-                latitude=latitudes[0],
-                longitude=longitudes[0],
-                location="North America",
-                capacity=1288.4,
-                type=archetype,
-            )
-            for archetype in [
-                "Gas",
-                "Gas/Gas",
-                "Gas/Steam",
-                "Gas/Steam/Dry",
-                "Gas/Steam/OnceThrough",
-                "Gas/Steam/Recirculating",
-            ]
+        for archetype in [
+            "Gas",
+            "Gas/Gas",
+            "Gas/Steam",
+            "Gas/Steam/Dry",
+            "Gas/Steam/OnceThrough",
+            "Gas/Steam/Recirculating",
         ]
+    ]
 
-        assets_provided_in_the_request = False
+    assets_provided_in_the_request = False
 
+    request_dict = {
+        "assets": Assets(
+            items=(
+                [
+                    Asset(
+                        asset_class=asset.__class__.__name__,
+                        latitude=asset.latitude,
+                        longitude=asset.longitude,
+                        type=asset.type,
+                        capacity=asset.capacity,
+                        location=asset.location,
+                    )
+                    for asset in assets
+                ]
+                if assets_provided_in_the_request
+                else []
+            )
+        ),
+        "include_asset_level": True,
+        "include_calc_details": True,
+        "years": [2050],
+        "scenarios": ["ssp585"],
+    }
+
+    request = requests.AssetImpactRequest(**request_dict)  # type: ignore
+
+    source_paths = get_default_source_paths(EmbeddedInventory())
+    vulnerability_models = DictBasedVulnerabilityModels(
+        {
+            ThermalPowerGeneratingAsset: [
+                ThermalPowerGenerationAirTemperatureModel(),
+                ThermalPowerGenerationDroughtModel(),
+                ThermalPowerGenerationRiverineInundationModel(),
+                ThermalPowerGenerationWaterStressModel(),
+                ThermalPowerGenerationWaterTemperatureModel(),
+            ]
+        }
+    )
+
+    response = requests._get_asset_impacts(
+        request,
+        ZarrHazardModel(source_paths=source_paths, reader=ZarrReader(mocker_store)),
+        vulnerability_models=vulnerability_models,
+        assets=None if assets_provided_in_the_request else assets,
+    )
+    # Air Temperature
+    assert response.asset_impacts[0].impacts[0].impact_mean == pytest.approx(
+        0.0075618606988512764
+    )
+    assert response.asset_impacts[1].impacts[0].impact_mean == pytest.approx(
+        0.0075618606988512764
+    )
+    assert response.asset_impacts[2].impacts[0].impact_mean == pytest.approx(
+        0.0025192163596997963
+    )
+    assert response.asset_impacts[3].impacts[0].impact_mean == pytest.approx(
+        0.0025192163596997963
+    )
+    assert response.asset_impacts[4].impacts[0].impact_mean == pytest.approx(0.0)
+    assert response.asset_impacts[5].impacts[0].impact_mean == pytest.approx(0.0)
+
+    # Drought
+    assert response.asset_impacts[0].impacts[1].impact_mean == pytest.approx(
+        0.0008230079663917424
+    )
+    assert response.asset_impacts[1].impacts[1].impact_mean == pytest.approx(0.0)
+    assert response.asset_impacts[2].impacts[1].impact_mean == pytest.approx(
+        0.0008230079663917424
+    )
+    assert response.asset_impacts[3].impacts[1].impact_mean == pytest.approx(0.0)
+    assert response.asset_impacts[4].impacts[1].impact_mean == pytest.approx(
+        0.0008230079663917424
+    )
+    assert response.asset_impacts[5].impacts[1].impact_mean == pytest.approx(
+        0.0008230079663917424
+    )
+
+    # Riverine Inundation
+    assert response.asset_impacts[0].impacts[2].impact_mean == pytest.approx(
+        0.0046864436945997625
+    )
+    assert response.asset_impacts[1].impacts[2].impact_mean == pytest.approx(
+        0.0046864436945997625
+    )
+    assert response.asset_impacts[2].impacts[2].impact_mean == pytest.approx(
+        0.0046864436945997625
+    )
+    assert response.asset_impacts[3].impacts[2].impact_mean == pytest.approx(
+        0.0046864436945997625
+    )
+    assert response.asset_impacts[4].impacts[2].impact_mean == pytest.approx(
+        0.0046864436945997625
+    )
+    assert response.asset_impacts[5].impacts[2].impact_mean == pytest.approx(
+        0.0046864436945997625
+    )
+
+    # Water Stress
+    assert response.asset_impacts[0].impacts[3].impact_mean == pytest.approx(
+        0.010181435900296947
+    )
+    assert response.asset_impacts[1].impacts[3].impact_mean == pytest.approx(0.0)
+    assert response.asset_impacts[2].impacts[3].impact_mean == pytest.approx(
+        0.010181435900296947
+    )
+    assert response.asset_impacts[3].impacts[3].impact_mean == pytest.approx(0.0)
+    assert response.asset_impacts[4].impacts[3].impact_mean == pytest.approx(
+        0.010181435900296947
+    )
+    assert response.asset_impacts[5].impacts[3].impact_mean == pytest.approx(
+        0.010181435900296947
+    )
+
+    # Water Temperature
+    assert response.asset_impacts[0].impacts[4].impact_mean == pytest.approx(
+        0.1448076958069578
+    )
+    assert response.asset_impacts[1].impacts[4].impact_mean == pytest.approx(0.0)
+    assert response.asset_impacts[2].impacts[4].impact_mean == pytest.approx(
+        0.1448076958069578
+    )
+    assert response.asset_impacts[3].impacts[4].impact_mean == pytest.approx(0.0)
+    assert response.asset_impacts[4].impacts[4].impact_mean == pytest.approx(
+        0.1448076958069578
+    )
+    assert response.asset_impacts[5].impacts[4].impact_mean == pytest.approx(
+        0.005896707722257193
+    )
+
+    vulnerability_models = DictBasedVulnerabilityModels(
+        {
+            ThermalPowerGeneratingAsset: [
+                ThermalPowerGenerationDroughtModel(impact_based_on_a_single_point=True),
+            ]
+        }
+    )
+    response = requests._get_asset_impacts(
+        request,
+        ZarrHazardModel(source_paths=source_paths, reader=ZarrReader(mocker_store)),
+        vulnerability_models=vulnerability_models,
+        assets=None if assets_provided_in_the_request else assets,
+    )
+
+    # Drought (Jupiter)
+    assert response.asset_impacts[0].impacts[0].impact_mean == pytest.approx(
+        0.0005859470850072303
+    )
+    assert response.asset_impacts[1].impacts[0].impact_mean == pytest.approx(0.0)
+    assert response.asset_impacts[2].impacts[0].impact_mean == pytest.approx(
+        0.0005859470850072303
+    )
+    assert response.asset_impacts[3].impacts[0].impact_mean == pytest.approx(0.0)
+    assert response.asset_impacts[4].impacts[0].impact_mean == pytest.approx(
+        0.0005859470850072303
+    )
+    assert response.asset_impacts[5].impacts[0].impact_mean == pytest.approx(
+        0.0005859470850072303
+    )
+
+
+@pytest.fixture
+def mocker_store():
+    latitudes = np.array([32.6017])
+    longitudes = np.array([-87.7811])
+    store, root = zarr_memory_store()
+    # Add mock riverine inundation data:
+    return_periods = [2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0]
+    shape, t = shape_transform_21600_43200(return_periods=return_periods)
+    add_curves(
+        root,
+        longitudes,
+        latitudes,
+        "inundation/wri/v2/inunriver_rcp4p5_MIROC-ESM-CHEM_2030",
+        shape,
+        np.array(
+            [
+                8.378922939300537e-05,
+                0.3319014310836792,
+                0.7859689593315125,
+                1.30947744846344,
+                1.6689927577972412,
+                2.002290964126587,
+                2.416414737701416,
+                2.7177860736846924,
+                3.008821725845337,
+            ]
+        ),
+        return_periods,
+        t,
+    )
+    add_curves(
+        root,
+        longitudes,
+        latitudes,
+        "inundation/wri/v2/inunriver_rcp8p5_MIROC-ESM-CHEM_2050",
+        shape,
+        np.array(
+            [
+                0.001158079132437706,
+                0.3938717246055603,
+                0.8549619913101196,
+                1.3880255222320557,
+                1.7519289255142212,
+                2.0910017490386963,
+                2.5129663944244385,
+                2.8202412128448486,
+                3.115604877471924,
+            ]
+        ),
+        return_periods,
+        t,
+    )
+
+    # Add mock drought data:
+    return_periods = [0.0, -1.0, -1.5, -2.0, -2.5, -3.0, -3.6]
+    shape, t = shape_transform_21600_43200(return_periods=return_periods)
+    add_curves(
+        root,
+        longitudes,
+        latitudes,
+        "drought/osc/v2/months_spei12m_below_threshold_multi_model_0_ssp585_2050/indicator",
+        shape,
+        np.array(
+            [
+                6.900000095367432,
+                1.7999999523162842,
+                0.44999998807907104,
+                0.06584064255906408,
+                0.06584064255906408,
+                0.0,
+                0.0,
+            ]
+        ),
+        return_periods,
+        t,
+    )
+
+    return_periods = [0.0]
+    shape, t = shape_transform_21600_43200(return_periods=return_periods)
+
+    # Add mock drought (Jupiter) data:
+    add_curves(
+        root,
+        longitudes,
+        latitudes,
+        "drought/jupiter/v1/months_spei3m_below_-2_ssp585_2050",
+        shape,
+        np.array([0.06584064255906408]),
+        return_periods,
+        t,
+    )
+
+    # Add mock water-related risk data:
+    add_curves(
+        root,
+        longitudes,
+        latitudes,
+        "water_risk/wri/v2/water_stress_ssp585_2050",
+        shape,
+        np.array([0.14204320311546326]),
+        return_periods,
+        t,
+    )
+    add_curves(
+        root,
+        longitudes,
+        latitudes,
+        "water_risk/wri/v2/water_supply_ssp585_2050",
+        shape,
+        np.array([76.09415435791016]),
+        return_periods,
+        t,
+    )
+    add_curves(
+        root,
+        longitudes,
+        latitudes,
+        "water_risk/wri/v2/water_supply_historical_1999",
+        shape,
+        np.array([88.62285614013672]),
+        return_periods,
+        t,
+    )
+
+    # Add mock chronic heat data:
+    add_curves(
+        root,
+        longitudes,
+        latitudes,
+        "chronic_heat/osc/v2/days_tas_above_25c_ACCESS-CM2_ssp585_2050",
+        shape,
+        np.array([148.55369567871094]),
+        return_periods,
+        t,
+    )
+    add_curves(
+        root,
+        longitudes,
+        latitudes,
+        "chronic_heat/osc/v2/days_tas_above_30c_ACCESS-CM2_ssp585_2050",
+        shape,
+        np.array([65.30751037597656]),
+        return_periods,
+        t,
+    )
+    add_curves(
+        root,
+        longitudes,
+        latitudes,
+        "chronic_heat/osc/v2/days_tas_above_35c_ACCESS-CM2_ssp585_2050",
+        shape,
+        np.array([0.6000000238418579]),
+        return_periods,
+        t,
+    )
+    add_curves(
+        root,
+        longitudes,
+        latitudes,
+        "chronic_heat/osc/v2/days_tas_above_40c_ACCESS-CM2_ssp585_2050",
+        shape,
+        np.array([0.0]),
+        return_periods,
+        t,
+    )
+    add_curves(
+        root,
+        longitudes,
+        latitudes,
+        "chronic_heat/osc/v2/days_tas_above_45c_ACCESS-CM2_ssp585_2050",
+        shape,
+        np.array([0.0]),
+        return_periods,
+        t,
+    )
+    add_curves(
+        root,
+        longitudes,
+        latitudes,
+        "chronic_heat/osc/v2/days_tas_above_50c_ACCESS-CM2_ssp585_2050",
+        shape,
+        np.array([0.0]),
+        return_periods,
+        t,
+    )
+    add_curves(
+        root,
+        longitudes,
+        latitudes,
+        "chronic_heat/osc/v2/days_tas_above_55c_ACCESS-CM2_ssp585_2050",
+        shape,
+        np.array([0.0]),
+        return_periods,
+        t,
+    )
+    add_curves(
+        root,
+        longitudes,
+        latitudes,
+        "chronic_heat/osc/v2/days_tas_above_25c_ACCESS-CM2_historical_2005",
+        shape,
+        np.array([120.51940155029297]),
+        return_periods,
+        t,
+    )
+    add_curves(
+        root,
+        longitudes,
+        latitudes,
+        "chronic_heat/osc/v2/days_tas_above_30c_ACCESS-CM2_historical_2005",
+        shape,
+        np.array([14.839207649230957]),
+        return_periods,
+        t,
+    )
+    add_curves(
+        root,
+        longitudes,
+        latitudes,
+        "chronic_heat/osc/v2/days_tas_above_35c_ACCESS-CM2_historical_2005",
+        shape,
+        np.array([0.049863386899232864]),
+        return_periods,
+        t,
+    )
+    add_curves(
+        root,
+        longitudes,
+        latitudes,
+        "chronic_heat/osc/v2/days_tas_above_40c_ACCESS-CM2_historical_2005",
+        shape,
+        np.array([0.0]),
+        return_periods,
+        t,
+    )
+    add_curves(
+        root,
+        longitudes,
+        latitudes,
+        "chronic_heat/osc/v2/days_tas_above_45c_ACCESS-CM2_historical_2005",
+        shape,
+        np.array([0.0]),
+        return_periods,
+        t,
+    )
+    add_curves(
+        root,
+        longitudes,
+        latitudes,
+        "chronic_heat/osc/v2/days_tas_above_50c_ACCESS-CM2_historical_2005",
+        shape,
+        np.array([0.0]),
+        return_periods,
+        t,
+    )
+    add_curves(
+        root,
+        longitudes,
+        latitudes,
+        "chronic_heat/osc/v2/days_tas_above_55c_ACCESS-CM2_historical_2005",
+        shape,
+        np.array([0.0]),
+        return_periods,
+        t,
+    )
+
+    # Add mock water temperature data:
+    return_periods = [
+        5,
+        7.5,
+        10,
+        12.5,
+        15,
+        17.5,
+        20,
+        22.5,
+        25,
+        27.5,
+        30,
+        32.5,
+        35,
+        37.5,
+        40,
+    ]
+    shape, t = shape_transform_21600_43200(return_periods=return_periods)
+    add_curves(
+        root,
+        longitudes,
+        latitudes,
+        "chronic_heat/nluu/v2/weeks_water_temp_above_GFDL_historical_1991",
+        shape,
+        np.array(
+            [
+                52.0,
+                51.9,
+                49.666668,
+                45.066666,
+                38.0,
+                31.1,
+                26.0,
+                21.066668,
+                14.233334,
+                8.0333338,
+                5.0999999,
+                2.3666666,
+                6.6666669,
+                3.3333335,
+                0.0,
+            ]
+        ),
+        return_periods,
+        t,
+    )
+    add_curves(
+        root,
+        longitudes,
+        latitudes,
+        "chronic_heat/nluu/v2/weeks_water_temp_above_GFDL_rcp8p5_2050",
+        shape,
+        np.array(
+            [
+                51.85,
+                51.5,
+                50.25,
+                46.75,
+                41.95,
+                35.35,
+                29.4,
+                24.55,
+                20.15,
+                13.85,
+                6.75,
+                3.5,
+                1.3,
+                0.25,
+                0.1,
+            ]
+        ),
+        return_periods,
+        t,
+    )
+
+    # Add mock WBGT data:
+    return_periods = [5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60]
+    shape, t = shape_transform_21600_43200(return_periods=return_periods)
+    add_curves(
+        root,
+        longitudes,
+        latitudes,
+        "chronic_heat/osc/v2/days_wbgt_above_ACCESS-CM2_ssp585_2050",
+        shape,
+        np.array(
+            [
+                363.65054,
+                350.21094,
+                303.6388,
+                240.48442,
+                181.82924,
+                128.46844,
+                74.400276,
+                1.3997267,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ]
+        ),
+        return_periods,
+        t,
+    )
+    add_curves(
+        root,
+        longitudes,
+        latitudes,
+        "chronic_heat/osc/v2/days_wbgt_above_ACCESS-CM2_historical_2005",
+        shape,
+        np.array(
+            [
+                361.95273,
+                342.51804,
+                278.8146,
+                213.5123,
+                157.4511,
+                101.78238,
+                12.6897545,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ]
+        ),
+        return_periods,
+        t,
+    )
+    return store
+
+
+@pytest.mark.live_data("dev")
+def test_example_portfolios(tmp_path, clear_credentials):
+    example_portfolios = physrisk.requests._get_example_portfolios()
+    for name, assets in example_portfolios.items():
+        if name != "manufacturing":
+            continue
+        logger.info(f"Running example portfolio: {name}")
         request_dict = {
-            "assets": Assets(
-                items=(
-                    [
-                        Asset(
-                            asset_class=asset.__class__.__name__,
-                            latitude=asset.latitude,
-                            longitude=asset.longitude,
-                            type=asset.type,
-                            capacity=asset.capacity,
-                            location=asset.location,
-                        )
-                        for asset in assets
-                    ]
-                    if assets_provided_in_the_request
-                    else []
-                )
-            ),
+            "assets": assets,
             "include_asset_level": True,
-            "include_calc_details": True,
-            "years": [2050],
+            "include_calc_details": False,
+            "include_measures": True,
+            "years": [2030, 2040, 2050],
             "scenarios": ["ssp585"],
         }
-
-        request = requests.AssetImpactRequest(**request_dict)  # type: ignore
-
-        store, root = zarr_memory_store()
-
-        # Add mock riverine inundation data:
-        return_periods = [2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0]
-        shape, t = shape_transform_21600_43200(return_periods=return_periods)
-        add_curves(
-            root,
-            longitudes,
-            latitudes,
-            "inundation/wri/v2/inunriver_rcp4p5_MIROC-ESM-CHEM_2030",
-            shape,
-            np.array(
-                [
-                    8.378922939300537e-05,
-                    0.3319014310836792,
-                    0.7859689593315125,
-                    1.30947744846344,
-                    1.6689927577972412,
-                    2.002290964126587,
-                    2.416414737701416,
-                    2.7177860736846924,
-                    3.008821725845337,
-                ]
-            ),
-            return_periods,
-            t,
+        container = Container()
+        requester = container.requester()
+        response = requester.get(
+            request_id="get_asset_impact", request_dict=request_dict
         )
-        add_curves(
-            root,
-            longitudes,
-            latitudes,
-            "inundation/wri/v2/inunriver_rcp8p5_MIROC-ESM-CHEM_2050",
-            shape,
-            np.array(
-                [
-                    0.001158079132437706,
-                    0.3938717246055603,
-                    0.8549619913101196,
-                    1.3880255222320557,
-                    1.7519289255142212,
-                    2.0910017490386963,
-                    2.5129663944244385,
-                    2.8202412128448486,
-                    3.115604877471924,
-                ]
-            ),
-            return_periods,
-            t,
+        with open(os.path.join(tmp_path, "out.json"), "w") as f:
+            f.write(response)
+        risk_measures_dict = json.loads(response)["risk_measures"]
+        helper = RiskMeasuresHelper(
+            TypeAdapter(RiskMeasures).validate_python(risk_measures_dict)
         )
-
-        # Add mock drought data:
-        return_periods = [0.0, -1.0, -1.5, -2.0, -2.5, -3.0, -3.6]
-        shape, t = shape_transform_21600_43200(return_periods=return_periods)
-        add_curves(
-            root,
-            longitudes,
-            latitudes,
-            "drought/osc/v2/months_spei12m_below_threshold_multi_model_0_ssp585_2050/indicator",
-            shape,
-            np.array(
-                [
-                    6.900000095367432,
-                    1.7999999523162842,
-                    0.44999998807907104,
-                    0.06584064255906408,
-                    0.06584064255906408,
-                    0.0,
-                    0.0,
-                ]
-            ),
-            return_periods,
-            t,
-        )
-
-        return_periods = [0.0]
-        shape, t = shape_transform_21600_43200(return_periods=return_periods)
-
-        # Add mock drought (Jupiter) data:
-        add_curves(
-            root,
-            longitudes,
-            latitudes,
-            "drought/jupiter/v1/months_spei3m_below_-2_ssp585_2050",
-            shape,
-            np.array([0.06584064255906408]),
-            return_periods,
-            t,
-        )
-
-        # Add mock water-related risk data:
-        add_curves(
-            root,
-            longitudes,
-            latitudes,
-            "water_risk/wri/v2/water_stress_ssp585_2050",
-            shape,
-            np.array([0.14204320311546326]),
-            return_periods,
-            t,
-        )
-        add_curves(
-            root,
-            longitudes,
-            latitudes,
-            "water_risk/wri/v2/water_supply_ssp585_2050",
-            shape,
-            np.array([76.09415435791016]),
-            return_periods,
-            t,
-        )
-        add_curves(
-            root,
-            longitudes,
-            latitudes,
-            "water_risk/wri/v2/water_supply_historical_1999",
-            shape,
-            np.array([88.62285614013672]),
-            return_periods,
-            t,
-        )
-
-        # Add mock chronic heat data:
-        add_curves(
-            root,
-            longitudes,
-            latitudes,
-            "chronic_heat/osc/v2/days_tas_above_25c_ACCESS-CM2_ssp585_2050",
-            shape,
-            np.array([148.55369567871094]),
-            return_periods,
-            t,
-        )
-        add_curves(
-            root,
-            longitudes,
-            latitudes,
-            "chronic_heat/osc/v2/days_tas_above_30c_ACCESS-CM2_ssp585_2050",
-            shape,
-            np.array([65.30751037597656]),
-            return_periods,
-            t,
-        )
-        add_curves(
-            root,
-            longitudes,
-            latitudes,
-            "chronic_heat/osc/v2/days_tas_above_35c_ACCESS-CM2_ssp585_2050",
-            shape,
-            np.array([0.6000000238418579]),
-            return_periods,
-            t,
-        )
-        add_curves(
-            root,
-            longitudes,
-            latitudes,
-            "chronic_heat/osc/v2/days_tas_above_40c_ACCESS-CM2_ssp585_2050",
-            shape,
-            np.array([0.0]),
-            return_periods,
-            t,
-        )
-        add_curves(
-            root,
-            longitudes,
-            latitudes,
-            "chronic_heat/osc/v2/days_tas_above_45c_ACCESS-CM2_ssp585_2050",
-            shape,
-            np.array([0.0]),
-            return_periods,
-            t,
-        )
-        add_curves(
-            root,
-            longitudes,
-            latitudes,
-            "chronic_heat/osc/v2/days_tas_above_50c_ACCESS-CM2_ssp585_2050",
-            shape,
-            np.array([0.0]),
-            return_periods,
-            t,
-        )
-        add_curves(
-            root,
-            longitudes,
-            latitudes,
-            "chronic_heat/osc/v2/days_tas_above_55c_ACCESS-CM2_ssp585_2050",
-            shape,
-            np.array([0.0]),
-            return_periods,
-            t,
-        )
-        add_curves(
-            root,
-            longitudes,
-            latitudes,
-            "chronic_heat/osc/v2/days_tas_above_25c_ACCESS-CM2_historical_2005",
-            shape,
-            np.array([120.51940155029297]),
-            return_periods,
-            t,
-        )
-        add_curves(
-            root,
-            longitudes,
-            latitudes,
-            "chronic_heat/osc/v2/days_tas_above_30c_ACCESS-CM2_historical_2005",
-            shape,
-            np.array([14.839207649230957]),
-            return_periods,
-            t,
-        )
-        add_curves(
-            root,
-            longitudes,
-            latitudes,
-            "chronic_heat/osc/v2/days_tas_above_35c_ACCESS-CM2_historical_2005",
-            shape,
-            np.array([0.049863386899232864]),
-            return_periods,
-            t,
-        )
-        add_curves(
-            root,
-            longitudes,
-            latitudes,
-            "chronic_heat/osc/v2/days_tas_above_40c_ACCESS-CM2_historical_2005",
-            shape,
-            np.array([0.0]),
-            return_periods,
-            t,
-        )
-        add_curves(
-            root,
-            longitudes,
-            latitudes,
-            "chronic_heat/osc/v2/days_tas_above_45c_ACCESS-CM2_historical_2005",
-            shape,
-            np.array([0.0]),
-            return_periods,
-            t,
-        )
-        add_curves(
-            root,
-            longitudes,
-            latitudes,
-            "chronic_heat/osc/v2/days_tas_above_50c_ACCESS-CM2_historical_2005",
-            shape,
-            np.array([0.0]),
-            return_periods,
-            t,
-        )
-        add_curves(
-            root,
-            longitudes,
-            latitudes,
-            "chronic_heat/osc/v2/days_tas_above_55c_ACCESS-CM2_historical_2005",
-            shape,
-            np.array([0.0]),
-            return_periods,
-            t,
-        )
-
-        # Add mock water temperature data:
-        return_periods = [
-            5,
-            7.5,
-            10,
-            12.5,
-            15,
-            17.5,
-            20,
-            22.5,
-            25,
-            27.5,
-            30,
-            32.5,
-            35,
-            37.5,
-            40,
-        ]
-        shape, t = shape_transform_21600_43200(return_periods=return_periods)
-        add_curves(
-            root,
-            longitudes,
-            latitudes,
-            "chronic_heat/nluu/v2/weeks_water_temp_above_GFDL_historical_1991",
-            shape,
-            np.array(
-                [
-                    52.0,
-                    51.9,
-                    49.666668,
-                    45.066666,
-                    38.0,
-                    31.1,
-                    26.0,
-                    21.066668,
-                    14.233334,
-                    8.0333338,
-                    5.0999999,
-                    2.3666666,
-                    6.6666669,
-                    3.3333335,
-                    0.0,
-                ]
-            ),
-            return_periods,
-            t,
-        )
-        add_curves(
-            root,
-            longitudes,
-            latitudes,
-            "chronic_heat/nluu/v2/weeks_water_temp_above_GFDL_rcp8p5_2050",
-            shape,
-            np.array(
-                [
-                    51.85,
-                    51.5,
-                    50.25,
-                    46.75,
-                    41.95,
-                    35.35,
-                    29.4,
-                    24.55,
-                    20.15,
-                    13.85,
-                    6.75,
-                    3.5,
-                    1.3,
-                    0.25,
-                    0.1,
-                ]
-            ),
-            return_periods,
-            t,
-        )
-
-        # Add mock WBGT data:
-        return_periods = [5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60]
-        shape, t = shape_transform_21600_43200(return_periods=return_periods)
-        add_curves(
-            root,
-            longitudes,
-            latitudes,
-            "chronic_heat/osc/v2/days_wbgt_above_ACCESS-CM2_ssp585_2050",
-            shape,
-            np.array(
-                [
-                    363.65054,
-                    350.21094,
-                    303.6388,
-                    240.48442,
-                    181.82924,
-                    128.46844,
-                    74.400276,
-                    1.3997267,
-                    0.0,
-                    0.0,
-                    0.0,
-                    0.0,
-                ]
-            ),
-            return_periods,
-            t,
-        )
-        add_curves(
-            root,
-            longitudes,
-            latitudes,
-            "chronic_heat/osc/v2/days_wbgt_above_ACCESS-CM2_historical_2005",
-            shape,
-            np.array(
-                [
-                    361.95273,
-                    342.51804,
-                    278.8146,
-                    213.5123,
-                    157.4511,
-                    101.78238,
-                    12.6897545,
-                    0.0,
-                    0.0,
-                    0.0,
-                    0.0,
-                    0.0,
-                ]
-            ),
-            return_periods,
-            t,
-        )
-
-        source_paths = get_default_source_paths(EmbeddedInventory())
-        vulnerability_models = DictBasedVulnerabilityModels(
-            {
-                ThermalPowerGeneratingAsset: [
-                    ThermalPowerGenerationAirTemperatureModel(),
-                    ThermalPowerGenerationDroughtModel(),
-                    ThermalPowerGenerationRiverineInundationModel(),
-                    ThermalPowerGenerationWaterStressModel(),
-                    ThermalPowerGenerationWaterTemperatureModel(),
-                ]
-            }
-        )
-
-        response = requests._get_asset_impacts(
-            request,
-            ZarrHazardModel(source_paths=source_paths, reader=ZarrReader(store)),
-            vulnerability_models=vulnerability_models,
-            assets=None if assets_provided_in_the_request else assets,
-        )
-
-        # Air Temperature
-        self.assertAlmostEqual(
-            response.asset_impacts[0].impacts[0].impact_mean, 0.0075618606988512764
-        )
-        self.assertAlmostEqual(
-            response.asset_impacts[1].impacts[0].impact_mean, 0.0075618606988512764
-        )
-        self.assertAlmostEqual(
-            response.asset_impacts[2].impacts[0].impact_mean, 0.0025192163596997963
-        )
-        self.assertAlmostEqual(
-            response.asset_impacts[3].impacts[0].impact_mean, 0.0025192163596997963
-        )
-        self.assertAlmostEqual(response.asset_impacts[4].impacts[0].impact_mean, 0.0)
-        self.assertAlmostEqual(response.asset_impacts[5].impacts[0].impact_mean, 0.0)
-
-        # Drought
-        self.assertAlmostEqual(
-            response.asset_impacts[0].impacts[1].impact_mean, 0.0008230079663917424
-        )
-        self.assertAlmostEqual(response.asset_impacts[1].impacts[1].impact_mean, 0.0)
-        self.assertAlmostEqual(
-            response.asset_impacts[2].impacts[1].impact_mean, 0.0008230079663917424
-        )
-        self.assertAlmostEqual(response.asset_impacts[3].impacts[1].impact_mean, 0.0)
-        self.assertAlmostEqual(
-            response.asset_impacts[4].impacts[1].impact_mean, 0.0008230079663917424
-        )
-        self.assertAlmostEqual(
-            response.asset_impacts[5].impacts[1].impact_mean, 0.0008230079663917424
-        )
-
-        # Riverine Inundation
-        self.assertAlmostEqual(
-            response.asset_impacts[0].impacts[2].impact_mean, 0.0046864436945997625
-        )
-        self.assertAlmostEqual(
-            response.asset_impacts[1].impacts[2].impact_mean, 0.0046864436945997625
-        )
-        self.assertAlmostEqual(
-            response.asset_impacts[2].impacts[2].impact_mean, 0.0046864436945997625
-        )
-        self.assertAlmostEqual(
-            response.asset_impacts[3].impacts[2].impact_mean, 0.0046864436945997625
-        )
-        self.assertAlmostEqual(
-            response.asset_impacts[4].impacts[2].impact_mean, 0.0046864436945997625
-        )
-        self.assertAlmostEqual(
-            response.asset_impacts[5].impacts[2].impact_mean, 0.0046864436945997625
-        )
-
-        # Water Stress
-        self.assertAlmostEqual(
-            response.asset_impacts[0].impacts[3].impact_mean, 0.010181435900296947
-        )
-        self.assertAlmostEqual(response.asset_impacts[1].impacts[3].impact_mean, 0.0)
-        self.assertAlmostEqual(
-            response.asset_impacts[2].impacts[3].impact_mean, 0.010181435900296947
-        )
-        self.assertAlmostEqual(response.asset_impacts[3].impacts[3].impact_mean, 0.0)
-        self.assertAlmostEqual(
-            response.asset_impacts[4].impacts[3].impact_mean, 0.010181435900296947
-        )
-        self.assertAlmostEqual(
-            response.asset_impacts[5].impacts[3].impact_mean, 0.010181435900296947
-        )
-
-        # Water Temperature
-        self.assertAlmostEqual(
-            response.asset_impacts[0].impacts[4].impact_mean, 0.1448076958069578
-        )
-        self.assertAlmostEqual(response.asset_impacts[1].impacts[4].impact_mean, 0.0)
-        self.assertAlmostEqual(
-            response.asset_impacts[2].impacts[4].impact_mean, 0.1448076958069578
-        )
-        self.assertAlmostEqual(response.asset_impacts[3].impacts[4].impact_mean, 0.0)
-        self.assertAlmostEqual(
-            response.asset_impacts[4].impacts[4].impact_mean, 0.1448076958069578
-        )
-        self.assertAlmostEqual(
-            response.asset_impacts[5].impacts[4].impact_mean,
-            0.005896707722257193,
-            delta=1e-6,
-        )
-
-        vulnerability_models = DictBasedVulnerabilityModels(
-            {
-                ThermalPowerGeneratingAsset: [
-                    ThermalPowerGenerationDroughtModel(
-                        impact_based_on_a_single_point=True
-                    ),
-                ]
-            }
-        )
-
-        response = requests._get_asset_impacts(
-            request,
-            ZarrHazardModel(source_paths=source_paths, reader=ZarrReader(store)),
-            vulnerability_models=vulnerability_models,
-            assets=None if assets_provided_in_the_request else assets,
-        )
-
-        # Drought (Jupiter)
-        self.assertAlmostEqual(
-            response.asset_impacts[0].impacts[0].impact_mean, 0.0005859470850072303
-        )
-        self.assertAlmostEqual(response.asset_impacts[1].impacts[0].impact_mean, 0.0)
-        self.assertAlmostEqual(
-            response.asset_impacts[2].impacts[0].impact_mean, 0.0005859470850072303
-        )
-        self.assertAlmostEqual(response.asset_impacts[3].impacts[0].impact_mean, 0.0)
-        self.assertAlmostEqual(
-            response.asset_impacts[4].impacts[0].impact_mean, 0.0005859470850072303
-        )
-        self.assertAlmostEqual(
-            response.asset_impacts[5].impacts[0].impact_mean, 0.0005859470850072303
-        )
+        for hazard_type in [
+            "CoastalInundation",
+            "ChronicHeat",
+            "Drought",
+            "Fire",
+            "Hail",
+            "RiverineInundation",
+            "Wind",
+        ]:
+            scores, measure_values, measure_defns = helper.get_measure(
+                hazard_type, "ssp585", 2050
+            )
+            if not scores:
+                logger.info(f"No scores for hazard type: {hazard_type}")
+                continue
+            label, description = helper.get_score_details(scores[0], measure_defns[0])
+            logger.info(
+                f"Hazard: {hazard_type}, Scores: {scores}, Measures: {measure_values}"
+            )
 
 
 def test_json_nan_protection():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,12 +47,32 @@ def load_credentials():
     return "loaded"
 
 
+@pytest.fixture()
+def clear_credentials(monkeypatch):
+    """Use the public OSC bucket anonymously for tests that need live data."""
+    credential_keys = (
+        "OSC_S3_ACCESS_KEY",
+        "OSC_S3_SECRET_KEY",
+        "OSC_S3_BUCKET",
+        "OSC_S3_HAZARD_PATH",
+        "OSC_S3_ENDPOINT",
+    )
+
+    for key in credential_keys:
+        monkeypatch.delenv(key, raising=False)
+
+
 @pytest.fixture(autouse=True)
-def skip_if_needs_live_data(request, load_credentials):
+def skip_if_needs_live_data(request):
     env = os.environ.get("PHYSRISK_ENVIRONMENT", "")
-    if request.node.get_closest_marker("live_data"):
-        if request.node.get_closest_marker("live_data").args[0] != env:
-            pytest.skip(f"skipped: PHYSRISK_ENVIRONMENT set to {env}")
+
+    marker = request.node.get_closest_marker("live_data")
+    if marker:
+        if not marker.args:
+            raise ValueError("live_data marker requires at least one environment")
+
+        if env not in marker.args:
+            pytest.skip(f"skipped: PHYSRISK_ENVIRONMENT={env}, required={marker.args}")
 
 
 @pytest.fixture

--- a/tests/kernel/test_live_services.py
+++ b/tests/kernel/test_live_services.py
@@ -1,10 +1,8 @@
 import json
 import logging
-from pydantic import TypeAdapter
 import pytest
 import requests
 
-from physrisk.api.v1.impact_req_resp import RiskMeasures, RiskMeasuresHelper
 from physrisk.container import Container
 import physrisk.requests
 from tests.conftest import get_result_expected
@@ -86,53 +84,6 @@ def test_live_hazard_data():
 
 
 @pytest.mark.skip("only as example")
-def test_example_portfolios():
-    example_portfolios = physrisk.requests._get_example_portfolios()
-    for name, assets in example_portfolios.items():
-        if name != "manufacturing":
-            continue
-        logger.info(f"Running example portfolio: {name}")
-        request_dict = {
-            "assets": assets,
-            "include_asset_level": True,
-            "include_calc_details": False,
-            "include_measures": True,
-            "years": [2030, 2040, 2050],
-            "scenarios": ["ssp585"],
-        }
-        container = Container()
-        requester = container.requester()
-        response = requester.get(
-            request_id="get_asset_impact", request_dict=request_dict
-        )
-        # with open("result.json", "w") as f:
-        #    f.write(response)
-        risk_measures_dict = json.loads(response)["risk_measures"]
-        helper = RiskMeasuresHelper(
-            TypeAdapter(RiskMeasures).validate_python(risk_measures_dict)
-        )
-        for hazard_type in [
-            "CoastalInundation",
-            "ChronicHeat",
-            "Drought",
-            "Fire",
-            "Hail",
-            "RiverineInundation",
-            "Wind",
-        ]:
-            scores, measure_values, measure_defns = helper.get_measure(
-                hazard_type, "ssp585", 2050
-            )
-            if not scores:
-                logger.info(f"No scores for hazard type: {hazard_type}")
-                continue
-            label, description = helper.get_score_details(scores[0], measure_defns[0])
-            logger.info(
-                f"Hazard: {hazard_type}, Scores: {scores}, Measures: {measure_values}"
-            )
-
-
-@pytest.mark.skip("only as example")
 def test_get_image_info():
     request = {
         "resource": "inundation/river_tudelft/v2/flood_depth_unprot_{scenario}_{year}",
@@ -148,11 +99,12 @@ def test_get_image_info():
 
 
 @pytest.fixture
-def requester():
+def requester(clear_credentials):
     container = Container()
     return container.requester()
 
 
+@pytest.mark.live_data("dev")
 def test_live_impacts_regression(
     requester: physrisk.requests.Requester, update_expected: str
 ):  # "latitude": 34.556, "longitude": 69.4787


### PR DESCRIPTION
This pull request migrates the API request tests (`test_data_request.py` and `test_impact_request.py`) from unittest to pytest.
 
It also moves `test_example_portfolios` from `test_live_services.py` into `test_impact_request.py`, where it fits better because it exercises the API request/response path rather than isolated kernel logic.
 
It adds `test_available_sources` to cover the `get_available_sources` endpoint.
 
`conftest.py` is updated to support this migration by adding `clear_credentials` fixture for tests that should use the public OSC bucket anonymously, and by improving `live_data` marker handling so live tests are skipped unless `PHYSRISK_ENVIRONMENT` matches the requested environment.
 
For now, this PR only covers the API request tests as a focused example of how we plan to migrate the test suite from unittest to pytest. A follow-up PR will extend this approach to the remaining tests.

Co-authored-by: Juan Román Roche <jroman@arfimaconsulting.com>
Co-authored-by: Martxel Aranzadi Olazabal <maranzadi@arfima.com>
Co-authored-by: Violeta Crespo Cobas <vcrespo@arfima.com>
Co-authored-by: Jonathan Yanez Vargas <jyanez@arfima.com>
Co-authored-by: Arfima Dev <dev@arfima.com>
Co-authored-by: Virginia Morales <vmorales@arfima.com>
Co-authored-by: Víctor de Luna <vdeluna@arfima.com>
Co-authored-by: Xavier Barrachina Civera <xbarrachina@arfima.com>
Signed-off-by: Yulian Lyubomirov Cenov <ycenov@arfima.com>
