### PR TITLE
Minor bug fix

### DIFF
--- a/src/physrisk/api/v1/availability_sources.py
+++ b/src/physrisk/api/v1/availability_sources.py
@@ -10,10 +10,6 @@ class AvailabilitySourcesRequest(BaseModel):
         False,
         description="If true, brings back all available information about years and scenarios per each hazard",
     )
-    use_case_id: str = Field(
-        "DEFAULT",
-        description="Use case id determines which set of hazards will be taken into account depending on the selected vulnerability models",
-    )
     selected_hazards_list: list[str] = Field(
         [], description="Specify which list of hazards the data is required for"
     )

--- a/src/physrisk/hazard_models/core_hazards.py
+++ b/src/physrisk/hazard_models/core_hazards.py
@@ -1,8 +1,9 @@
 from enum import Enum
+import logging
+from pathlib import PurePosixPath
 from typing import Dict, Iterable, List, NamedTuple, Optional, Protocol, Sequence, Type
 import re
 from collections import defaultdict
-from pathlib import PurePosixPath
 
 from physrisk.api.v1.hazard_data import HazardResource
 from physrisk.data.hazard_data_provider import (
@@ -22,6 +23,8 @@ from physrisk.kernel.hazards import (
     Wind,
     hazard_class,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class ResourceSubset:
@@ -255,7 +258,13 @@ class InventorySourcePaths(SourcePaths):
                 hazard,
                 indicator_id,
             ), _ in self._inventory.resources_by_type_id.items():
-                hazard_type = hazard_class(hazard)
+                try:
+                    hazard_type = hazard_class(hazard)
+                except AttributeError:
+                    logger.warning(
+                        f"unable to find hazard class for hazard {hazard}, skipping"
+                    )
+                    continue
 
                 selected = self.get_resources(
                     hazard_type=hazard_type, indicator_id=indicator_id, hint=None

--- a/tests/hazard_models/test_core_hazards.py
+++ b/tests/hazard_models/test_core_hazards.py
@@ -1,0 +1,28 @@
+from physrisk.api.v1.hazard_data import HazardResource, Scenario
+from physrisk.data.inventory import Inventory
+from physrisk.hazard_models.core_hazards import InventorySourcePaths
+
+
+def _hazard_resource(hazard_type: str, indicator_id: str) -> HazardResource:
+    return HazardResource(
+        path=f"test/{hazard_type}/{indicator_id}/{{scenario}}_{{year}}",
+        hazard_type=hazard_type,
+        indicator_id=indicator_id,
+        indicator_model_gcm="test_gcm",
+        display_name=f"{hazard_type} {indicator_id}",
+        description="Test hazard resource",
+        scenarios=[Scenario(id="ssp585", years=[2030])],
+        units="test_units",
+    )
+
+
+def test_all_selected_resources_by_type_id_skips_hazards_without_class() -> None:
+    known_resource = _hazard_resource("ChronicHeat", "test_indicator")
+    unknown_resource = _hazard_resource("UnknownHazard", "test_indicator")
+    inventory = Inventory(hazard_resources=[known_resource, unknown_resource])
+    source_paths = InventorySourcePaths(inventory)
+
+    selected_resources = source_paths.all_selected_resources_by_type_id
+
+    assert selected_resources[("ChronicHeat", "test_indicator")] == [known_resource]
+    assert ("UnknownHazard", "test_indicator") not in selected_resources


### PR DESCRIPTION
This is a bug fix to the downstream logic of the new get_available_sources endpoint that we contributed in #579. We detected that if the inventory contains a resource for a hazard that is not defined in physrisk, the attribute `all_selected_resources_by_type_id` will throw an `AttributeError` when attempting to convert the hazard name string into a hazard class.

We implement a test to reproduce the error and then fix it by catching the exception, logging the missing hazard and continuing the loop.