### PR TITLE
Add Landslide and Earthquake hazards and other typing changes

### DIFF
--- a/src/physrisk/data/hazard_data_provider.py
+++ b/src/physrisk/data/hazard_data_provider.py
@@ -206,7 +206,7 @@ class HazardDataProvider(ABC):
         # mask_unprocessed is the mask of lats and lons that remain unprocessed.
         # This always has the same length and is updated for each path_item.
         # combined data for each year
-        mask_unprocessed = np.ones(len(longitudes), dtype=np.bool)
+        mask_unprocessed = np.ones(len(longitudes), dtype=bool)
         resource_paths_set: List[ResourcePaths] = self._source_paths.resource_paths(
             self.hazard_type,
             indicator_id=indicator_id,
@@ -284,7 +284,7 @@ class HazardDataProvider(ABC):
                     indices=indices,
                     indices_length=indices_length,
                     coverage_mask=np.zeros(
-                        len(longitudes), dtype=np.bool
+                        len(longitudes), dtype=bool
                     ),  # ~mask_unprocessed,
                     units=v.units,
                     paths=paths,

--- a/src/physrisk/data/inventory_reader.py
+++ b/src/physrisk/data/inventory_reader.py
@@ -62,7 +62,7 @@ class InventoryReader:
         md: Dict[str, str] = {}
         for path in paths:
             try:
-                with self._fs.open(self._full_path(path), "r") as f:
+                with self._fs.open(self._full_path(path), "r", encoding="utf-8") as f:
                     md[path] = f.read()
             finally:
                 continue
@@ -70,7 +70,7 @@ class InventoryReader:
 
     def read_json(self, path: str) -> str:
         """Read inventory at path provided and return json."""
-        with self._fs.open(self._full_path(path), "r") as f:
+        with self._fs.open(self._full_path(path), "r", encoding="utf-8") as f:
             json_str = f.read()
         return json_str
 
@@ -80,7 +80,7 @@ class InventoryReader:
             combined[model.key()] = model
         models = HazardModels(resources=list(combined.values()))
         json_str = json.dumps(models.model_dump())
-        with self._fs.open(self._full_path(path), "w") as f:
+        with self._fs.open(self._full_path(path), "w", encoding="utf-8") as f:
             f.write(json_str)
 
     def _full_path(self, path: str):

--- a/src/physrisk/hazard_models/core_hazards.py
+++ b/src/physrisk/hazard_models/core_hazards.py
@@ -21,6 +21,7 @@ from physrisk.kernel.hazards import (
     Hazard,
     RiverineInundation,
     Wind,
+    Landslide,
     hazard_class,
 )
 
@@ -311,6 +312,7 @@ class CoreInventorySourcePaths(InventorySourcePaths):
             CoastalInundation, "flood_depth", self._select_coastal_inundation
         )
         self.add_selector(Wind, "max_speed", self._select_wind)
+        self.add_selector(Landslide, "landslide_susceptability", self._select_landslide)
 
     def resources_with(self, *, hazard_type: type, indicator_id: str):
         return ResourceSubset(
@@ -363,6 +365,14 @@ class CoreInventorySourcePaths(InventorySourcePaths):
         hint: Optional[HazardDataHint] = None,
     ):
         return candidates.prefer_group_id("iris_osc").first()
+
+    @staticmethod
+    def _select_landslide(
+        *,
+        candidates: ResourceSubset,
+        hint: Optional[HazardDataHint] = None,
+    ) -> List[HazardResource]:
+        return candidates.with_group_id("landslide_jrc").first()
 
 
 def cmip6_scenario_to_rcp(scenario: str):

--- a/src/physrisk/kernel/assets.py
+++ b/src/physrisk/kernel/assets.py
@@ -17,7 +17,7 @@ project_3857_to_4326 = Transformer.from_crs(
 
 
 # 'primary_fuel' entries in Global Power Plant Database v1.3.0 (World Resources Institute)
-# https://wri-dataportal-prod.s3.amazonaws.com/manual/global_power_plant_database_v_1_3
+# https://datasets.wri.org/dataset/globalpowerplantdatabase
 class FuelKind(Enum):
     Biomass = 1
     Coal = 2

--- a/src/physrisk/kernel/hazards.py
+++ b/src/physrisk/kernel/hazards.py
@@ -79,6 +79,7 @@ class Fire(Hazard):
     kind = HazardKind.ACUTE
     indicator_data = {
         "fire_probability": IndicatorData.PARAMETERS,
+        "daily_probability_fwi20": IndicatorData.PARAMETERS,
     }
     pass
 
@@ -133,3 +134,11 @@ def all_hazards():
 
 def hazard_class(name: str) -> Type[Hazard]:
     return getattr(sys.modules[__name__], name)
+
+
+class Landslide(Hazard):
+    kind = HazardKind.ACUTE
+
+
+class Earthquake(Hazard):
+    kind = HazardKind.ACUTE

--- a/src/physrisk/kernel/risk.py
+++ b/src/physrisk/kernel/risk.py
@@ -176,8 +176,8 @@ class RiskMeasureCalculator(Protocol):
     def calc_measure(
         self,
         hazard_type: Type[Hazard],
-        base_impact: Sequence[AssetImpactResult],
-        impact: Sequence[AssetImpactResult],
+        base_impacts: Sequence[AssetImpactResult],
+        impacts: Sequence[AssetImpactResult],
     ) -> Measure | dict[str | None, Measure]:
         """Calculate the Measure (score-based risk measure) for the hazard,
         given the set of base (i.e. historical) and future asset-level impacts.

--- a/src/physrisk/requests.py
+++ b/src/physrisk/requests.py
@@ -249,7 +249,6 @@ class Requester:
             message = (
                 f"Empty for the combination of the following request parameters:\n"
                 f"include_all={request.include_all},\n"
-                f"USE_CASE_ID={request.use_case_id},\n"
                 f"selected_hazard_list={request.selected_hazards_list}"
             )
 
@@ -414,7 +413,9 @@ def _get_hazard_data_description(
 def _get_hazard_data(
     request: HazardDataRequest,
     hazard_model: HazardModel,
-    sig_figures: Callable[[Union[np.ndarray, float]], np.ndarray] = lambda x: x,
+    sig_figures: Callable[
+        [Union[np.ndarray, float]], Union[float, np.ndarray]
+    ] = lambda x: x,
 ):
     # if any(
     #     not _read_permitted(request.group_ids, inventory.resources_by_type_id[(i.event_type, i.model)][0])
@@ -471,16 +472,16 @@ def _get_hazard_data(
         intensity_curves = [
             (
                 IntensityCurve(
-                    intensities=list(sig_figures(resp.intensities)),
-                    index_values=list(sig_figures(resp.return_periods)),
+                    intensities=np.asarray(sig_figures(resp.intensities)).tolist(),
+                    index_values=np.asarray(sig_figures(resp.return_periods)).tolist(),
                     index_name="return period",
                     return_periods=[],
                 )
                 if isinstance(resp, hmHazardEventDataResponse)
                 else (
                     IntensityCurve(
-                        intensities=list(sig_figures(resp.parameters)),
-                        index_values=list(sig_figures(resp.param_defns)),
+                        intensities=np.asarray(sig_figures(resp.parameters)).tolist(),
+                        index_values=np.asarray(sig_figures(resp.param_defns)).tolist(),
                         index_name="threshold",
                         return_periods=[],
                     )
@@ -658,18 +659,28 @@ def compile_asset_impacts(
                 if v.event is not None and v.vulnerability is not None:
                     hazard_exceedance = v.event.to_exceedance_curve()
                     vulnerability_distribution = VulnerabilityDistrib(
-                        intensity_bin_edges=sig_figures(v.vulnerability.intensity_bins),
-                        impact_bin_edges=sig_figures(v.vulnerability.impact_bins),
-                        prob_matrix=sig_figures(v.vulnerability.prob_matrix),
+                        intensity_bin_edges=np.asarray(
+                            sig_figures(v.vulnerability.intensity_bins)
+                        ),
+                        impact_bin_edges=np.asarray(
+                            sig_figures(v.vulnerability.impact_bins)
+                        ),
+                        prob_matrix=np.asarray(
+                            sig_figures(v.vulnerability.prob_matrix)
+                        ),
                     )
                     calc_details = CalculationDetails(
                         hazard_exceedance=ExceedanceCurve(
-                            values=sig_figures(hazard_exceedance.values),
-                            exceed_probabilities=sig_figures(hazard_exceedance.probs),
+                            values=np.asarray(sig_figures(hazard_exceedance.values)),
+                            exceed_probabilities=np.asarray(
+                                sig_figures(hazard_exceedance.probs)
+                            ),
                         ),
                         hazard_distribution=Distribution(
-                            bin_edges=sig_figures(v.event.intensity_bin_edges),
-                            probabilities=sig_figures(v.event.prob),
+                            bin_edges=np.asarray(
+                                sig_figures(v.event.intensity_bin_edges)
+                            ),
+                            probabilities=np.asarray(sig_figures(v.event.prob)),
                         ),
                         vulnerability_distribution=vulnerability_distribution,
                         hazard_path=v.impact.path,

--- a/src/physrisk/vulnerability_models/config_based_impact_curves.py
+++ b/src/physrisk/vulnerability_models/config_based_impact_curves.py
@@ -98,6 +98,16 @@ class VulnerabilityConfigItem(BaseModel):
         "then the threshold applied will be 10 °C above the 90% quantile, i.e. 43 °C.",
     )
 
+    reference: Optional[str] = Field(
+        None,
+        description="Source of the vulnerability config model",
+    )
+
+    license: Optional[str] = Field(
+        None,
+        description="License in compact format, e.g., 'CC-BY-4.0'",
+    )
+
 
 def to_year_fraction_divisor(indicator_units: Optional[str]) -> float:
     if indicator_units is not None:

--- a/src/physrisk/vulnerability_models/real_estate_models.py
+++ b/src/physrisk/vulnerability_models/real_estate_models.py
@@ -89,8 +89,31 @@ class RealEstateInundationModel(VulnerabilityModel):
             impact_bin_edges=impact_bin_edges,
         )
 
-    def get_impact_curve(self, intensity_bin_centres: np.ndarray, asset: Asset):
-        """Calculate the impact curve based on flood intensity and asset characteristics."""
+    def get_impact_curve(
+        self, intensity_bin_centres: np.ndarray, asset: Asset
+    ) -> VulnMatrixProvider:
+        """Build vulnerability distributions for flood intensities for a given asset.
+
+        Args:
+        ----
+            intensity_bin_centres: One-dimensional array of hazard intensity bin
+                centres. Each value represents the midpoint of a discrete hazard
+                intensity interval and is used to match intensity levels to the
+                corresponding impacts from the vulnerability curve.
+            asset: Asset for which the vulnerability curve is required. When
+                ``asset`` is a ``RealEstateAsset``, its ``location`` and ``type`` are
+                used to select the appropriate curve. For a generic ``Asset``, the
+                fallback curve ``("Europe", "Buildings/Residential")`` is used.
+
+        Returns:
+        -------
+            VulnMatrixProvider: Provider containing one beta distribution-derived
+                impact CDF per intensity bin centre, constructed from interpolated
+                impact means and standard deviations from the selected
+                vulnerability curve, which defines the relationship between hazard
+                intensity and impact.
+
+        """
 
         # we interpolate the mean and standard deviation and use this to construct distributions
         if isinstance(asset, RealEstateAsset):
@@ -120,9 +143,28 @@ class RealEstateInundationModel(VulnerabilityModel):
             ],
         )
 
-    def closest_curve_of_type(self, curve: VulnerabilityCurve, asset_type: str):
-        """Find the closest matching vulnerability curve of the same type for interpolation."""
-        # we return the standard deviations of the damage curve most similar to the asset location
+    def closest_curve_of_type(
+        self, curve: VulnerabilityCurve, asset_type: str
+    ) -> VulnerabilityCurve:
+        """Find a proxy curve of the same asset type that includes standard deviations.
+
+        Args:
+        ----
+            curve: Vulnerability curve whose mean impact profile is used as the
+                reference when searching for the closest proxy.
+            asset_type: Asset type of the asset under evaluation. It is used to
+                restrict the search to compatible vulnerability curves, for
+                example ``"Buildings/Residential"``, so the selected proxy curve
+                best matches that asset class.
+
+        Returns:
+        -------
+            VulnerabilityCurve: The candidate curve of the requested asset type
+                with non-empty ``impact_std`` values and the smallest sum of
+                squared differences from ``curve`` across the reference
+                intensity grid.
+
+        """  # we return the standard deviations of the damage curve most similar to the asset location
         candidate_set = list(
             cand
             for cand in self.vuln_curves_by_type[asset_type]
@@ -132,8 +174,26 @@ class RealEstateInundationModel(VulnerabilityModel):
         lowest = np.argmin(np.array(list(sum_square_diff)))
         return candidate_set[lowest]
 
-    def sum_square_diff(self, curve1: VulnerabilityCurve, curve2: VulnerabilityCurve):
-        """Compute the sum of squared differences between two vulnerability curves."""
+    def sum_square_diff(
+        self, curve1: VulnerabilityCurve, curve2: VulnerabilityCurve
+    ) -> float:
+        """Compute a distance metric between two vulnerability curves.
+
+        Args:
+        ----
+            curve1: Reference vulnerability curve. Its intensity grid is used as
+                the comparison domain.
+            curve2: Curve to compare against ``curve1``. Its mean impacts are
+                interpolated onto the intensity values from ``curve1`` before the
+                difference is calculated.
+
+        Returns:
+        -------
+            float: Sum of squared differences between ``curve1.impact_mean`` and
+                the interpolated ``curve2.impact_mean`` values. Smaller values
+                indicate more similar curves.
+
+        """
         return np.sum(
             (
                 curve1.impact_mean
@@ -278,8 +338,25 @@ class CoolingModel(VulnerabilityModelBase):
         self.hazard_type = ChronicHeat
         self.threshold_temp_c = threshold_temp_c
 
-    def get_data_requests(self, asset: Asset, *, scenario: str, year: int):
-        """Provide the list of hazard event data requests required in order to calculate the VulnerabilityDistrib and HazardEventDistrib for the asset."""
+    def get_data_requests(
+        self, asset: Asset, *, scenario: str, year: int
+    ) -> HazardDataRequest:
+        """Build the hazard data request needed to estimate cooling demand.
+
+        Args:
+        ----
+            asset: Asset whose location and optional geometry define where hazard
+                parameter data should be requested.
+            scenario: Climate scenario identifier forwarded to the hazard model.
+            year: Projection year for which the hazard parameter data is required.
+
+        Returns:
+        -------
+            HazardDataRequest: Single request for chronic heat parameter data at
+                the asset coordinates, using this model's indicator identifier and
+                the asset geometry when available.
+
+        """
         return HazardDataRequest(
             self.hazard_type,
             asset.longitude,


### PR DESCRIPTION
This PR adds Landslide/Earthquake hazard support and a small set of other minor changes

- Add Landslide/Earthquake support, including Landslide source selection.
- Add Fire indicator support for daily_probability_fwi20.
- Improve typing and data-shape handling across hazard retrieval/output paths (including scalar vs array handling).
- Include small consistency cleanups in protocol naming, data I/O, deprecated dtype usage, and related docs/messages.

Co-authored-by: Juan Román Roche jroman@arfimaconsulting.com
Co-authored-by: Martxel Aranzadi Olazabal maranzadi@arfima.com
Co-authored-by: Arfima Dev dev@arfima.com
Signed-off-by: Yulian Lyubomirov Cenov ycenov@arfima.com