### PR TITLE
Deprecate fields and clean up validation

### DIFF
--- a/src/physrisk/api/v1/common.py
+++ b/src/physrisk/api/v1/common.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from typing import Annotated, List, Optional, Sequence, Union
 
 import numpy as np
@@ -21,20 +20,6 @@ NDArray = Annotated[
     BeforeValidator(before_validator),
     PlainSerializer(serialize_array, return_type=list),
 ]
-
-
-class HazardType(str, Enum):
-    coastal_inundation = "CoastalInundation"
-    chronic_heat = "ChronicHeat"
-    drought = "Drought"
-    fire = "Fire"
-    hail = "Hail"
-    pluvial_inundation = "PluvialInundation"
-    precipitation = "Precipitation"
-    riverine_inundation = "RiverineInundation"
-    subsidence = "Subsidence"
-    water_risk = "WaterRisk"
-    wind = "Wind"
 
 
 class Asset(BaseModel):

--- a/src/physrisk/api/v1/hazard_data.py
+++ b/src/physrisk/api/v1/hazard_data.py
@@ -1,9 +1,10 @@
 from enum import Flag, auto
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
-from pydantic import BaseModel, Field
+from pydantic import AliasChoices, BaseModel, Field, computed_field, field_validator
 
-from physrisk.api.v1.common import BaseHazardRequest, HazardType, IntensityCurve
+from physrisk.api.v1.common import BaseHazardRequest, IntensityCurve
+from physrisk.kernel.hazards import all_hazards
 
 
 class Colormap(BaseModel):
@@ -215,19 +216,44 @@ class StaticInformationResponse(BaseModel):
     )
 
 
+def _supported_hazard_type_names() -> set[str]:
+    return {hazard.__name__ for hazard in all_hazards()}
+
+
 class HazardDataRequestItem(BaseModel):
     longitudes: List[float]
     latitudes: List[float]
     request_item_id: str
-    hazard_type: Optional[HazardType] = None  # e.g. RiverineInundation
-    event_type: Optional[str] = (
-        None  # e.g. RiverineInundation; deprecated: use hazard_type
+    hazard_type: str | None = Field(
+        default=None,
+        description="Type of hazard, e.g. RiverineInundation.",
+        json_schema_extra={"enum": sorted(_supported_hazard_type_names())},
+        validation_alias=AliasChoices("hazard_type", "event_type"),
     )
     indicator_id: str
     indicator_model_gcm: Optional[str] = ""
     path: Optional[str] = None
     scenario: str  # e.g. rcp8p5
     year: int
+
+    @field_validator("hazard_type")
+    @classmethod
+    def validate_hazard_type(cls, hazard_type: Optional[str]) -> Optional[str]:
+        if hazard_type is None:
+            return None
+        supported_hazard_types = _supported_hazard_type_names()
+        if hazard_type not in supported_hazard_types:
+            raise ValueError(
+                f"hazard_type must be one of the hazard classes defined in physrisk.kernel.hazards. "
+                f"Got {hazard_type!r}; expected one of {sorted(supported_hazard_types)}."
+            )
+        return hazard_type
+
+    @computed_field(description="Deprecated: same as hazard_type")  # type: ignore[misc]
+    @property
+    def event_type(self) -> Optional[str]:
+        """Deprecated: use hazard_type instead."""
+        return self.hazard_type
 
 
 class HazardDataRequest(BaseHazardRequest):
@@ -299,10 +325,22 @@ class HazardDataRequest(BaseHazardRequest):
 class HazardDataResponseItem(BaseModel):
     intensity_curve_set: List[IntensityCurve]
     request_item_id: str
-    event_type: Optional[str]
-    model: str
+    hazard_type: str | None
+    indicator_id: str
     scenario: str
     year: int
+
+    @computed_field(description="Deprecated: same as hazard_type")  # type: ignore[misc]
+    @property
+    def event_type(self) -> str | None:
+        """Deprecated: use hazard_type instead."""
+        return self.hazard_type
+
+    @computed_field(description="Deprecated: same as indicator_id")  # type: ignore[misc]
+    @property
+    def model(self) -> str:
+        """Deprecated: use indicator_id instead."""
+        return self.indicator_id
 
 
 class HazardDataResponse(BaseModel):

--- a/src/physrisk/kernel/hazards.py
+++ b/src/physrisk/kernel/hazards.py
@@ -128,7 +128,7 @@ def all_hazards():
     return [
         obj
         for _, obj in inspect.getmembers(sys.modules[__name__])
-        if inspect.isclass(obj) and issubclass(obj, Hazard)
+        if inspect.isclass(obj) and issubclass(obj, Hazard) and obj is not Hazard
     ]
 
 

--- a/src/physrisk/requests.py
+++ b/src/physrisk/requests.py
@@ -44,7 +44,7 @@ from physrisk.hazard_models.core_hazards import (
     get_default_source_paths,
 )
 from physrisk.kernel.exposure import JupterExposureMeasure, calculate_exposures
-from physrisk.kernel.hazards import Hazard, hazard_class
+from physrisk.kernel.hazards import Hazard, all_hazards, hazard_class
 from physrisk.kernel.impact import AssetImpactResult, ImpactKey  # , ImpactKey
 from physrisk.kernel.impact_distrib import EmptyImpactDistrib, PlaceholderImpactDistrib
 from physrisk.kernel.risk import (
@@ -423,30 +423,19 @@ def _get_hazard_data(
     # ):
     #     raise PermissionError()
 
-    # get hazard event types:
-    event_types = Hazard.__subclasses__()
-    event_dict = dict((et.__name__, et) for et in event_types)
-    event_dict.update(
-        (est.__name__, est) for et in event_types for est in et.__subclasses__()
-    )
+    hazard_classes = {hazard.__name__: hazard for hazard in all_hazards()}
 
     # flatten list to let event processor decide how to group
     item_requests = []
     all_requests = []
     for item in request.items:
-        hazard_type = (
-            item.hazard_type
-            if item.hazard_type is not None
-            else item.event_type
-            if item.event_type is not None
-            else ""
-        )
-        event_type = event_dict[hazard_type]
+        hazard_type = item.hazard_type if item.hazard_type is not None else ""
+        hazard = hazard_classes[hazard_type]
         hint = None if item.path is None else HazardDataHint(path=item.path)
 
         data_requests = [
             hmHazardDataRequest(
-                event_type,
+                hazard,
                 lon,
                 lat,
                 indicator_id=item.indicator_id,
@@ -500,8 +489,8 @@ def _get_hazard_data(
             HazardDataResponseItem(
                 intensity_curve_set=intensity_curves,
                 request_item_id=item.request_item_id,
-                event_type=item.event_type,
-                model=item.indicator_id,
+                hazard_type=item.hazard_type,
+                indicator_id=item.indicator_id,
                 scenario=item.scenario,
                 year=item.year,
             )

--- a/tests/api/test_data_requests.py
+++ b/tests/api/test_data_requests.py
@@ -1,12 +1,14 @@
 import pytest
 import json
 import numpy as np
+from pydantic import ValidationError
 
 from physrisk.data.hazard_data_provider import HazardDataHint
 from physrisk.data.inventory import EmbeddedInventory
 from physrisk.data.pregenerated_hazard_model import ZarrHazardModel
 from physrisk.data.zarr_reader import ZarrReader
 from physrisk.hazard_models.core_hazards import get_default_source_paths
+from physrisk.api.v1.hazard_data import HazardDataRequestItem
 from physrisk.kernel.hazards import ChronicHeat, RiverineInundation
 from physrisk.container import Container
 from physrisk import requests
@@ -25,6 +27,19 @@ def test_hazard_data_availability():
     container.override(TestContainer())
     requester = container.requester()
     _ = requester.get(request_id="get_hazard_data_availability", request_dict={})
+
+
+def test_hazard_data_request_item_rejects_unknown_hazard_type():
+    with pytest.raises(ValidationError, match="NotAHazard"):
+        HazardDataRequestItem(
+            request_item_id="test_unknown",
+            hazard_type="NotAHazard",
+            longitudes=[20.3162],
+            latitudes=[45.4089],
+            year=2035,
+            scenario="ssp585",
+            indicator_id="hazard_indicator",
+        )
 
 
 @pytest.mark.live_data("dev")


### PR DESCRIPTION
In HazardDataResponseItem, we renamed the fields event_type -> hazard_type and model -> indicator_id for clarity. We maintain backward compatibility by exposing the old fields as deprecated computed fields.

We also cleaned up hazard type validation in hazard data requests by removing the dependency on a hazard-name enum and validating against hazard classes instead (single source of truth).

Co-authored-by: Martxel Aranzadi Olazabal maranzadi@arfima.com
Co-authored-by: Yulian Lyubomirov Cenov ycenov@arfima.com
Signed-off-by: Juan Román Roche jroman@arfimaconsulting.com