### PR TITLE
Register TU Delft Snow and FreezingRain hazards

### DIFF
--- a/src/physrisk/kernel/hazards.py
+++ b/src/physrisk/kernel/hazards.py
@@ -62,6 +62,9 @@ class CoastalInundation(Inundation):
 
 class ChronicWind(Hazard):
     kind = HazardKind.CHRONIC
+    indicator_data = {
+        "windstorm_probability": IndicatorData.EVENT,
+    }
     pass
 
 
@@ -79,7 +82,6 @@ class Fire(Hazard):
     kind = HazardKind.ACUTE
     indicator_data = {
         "fire_probability": IndicatorData.PARAMETERS,
-        "daily_probability_fwi20": IndicatorData.PARAMETERS,
     }
     pass
 
@@ -88,6 +90,7 @@ class Hail(Hazard):
     kind = HazardKind.ACUTE
     indicator_data = {
         "days/above/5cm": IndicatorData.PARAMETERS,
+        "hail_probability": IndicatorData.EVENT,
     }
     pass
 
@@ -121,6 +124,24 @@ class Wind(Hazard):
 
 class Subsidence(Hazard):
     kind = HazardKind.CHRONIC
+    pass
+
+
+class Snow(Hazard):
+    kind = HazardKind.ACUTE
+    indicator_data = {
+        "blizzard_probability": IndicatorData.PARAMETERS,
+        "heavy_snowfall_probability": IndicatorData.EVENT,
+        "crown_snow_load_probability": IndicatorData.EVENT,
+    }
+    pass
+
+
+class FreezingRain(Hazard):
+    kind = HazardKind.ACUTE
+    indicator_data = {
+        "freezing_rain_probability": IndicatorData.EVENT,
+    }
     pass
 
 


### PR DESCRIPTION
This PR contributes Snow and FreezingRain hazards, extends indicator data for existing hazards, and updates Fire indicator semantics.

- Add windstorm_probability indicator data to ChronicWind
- Update Fire indicator data:
  - Remove daily_probability_fwi20 now handled as an index indicator
- Extend Hail indicator data with:
  - hail_probability quitar 
- Add Snow hazard with indicator data for:
  - blizzard_probability
  - heavy_snowfall_probability quitar
  - crown_snow_load_probability
- Add FreezingRain hazard with indicator data for:
  - freezing_rain_probability

Co-authored-by: Carlos San Millán csanmillan@arfimaconsulting.com
Signed-off-by: Yulian Lyubomirov Cenov ycenov@arfima.com