### PR TITLE
Add log value-to-colour scaling for map images and tiles

### DIFF
--- a/src/physrisk/api/v1/hazard_data.py
+++ b/src/physrisk/api/v1/hazard_data.py
@@ -1,5 +1,5 @@
 from enum import Flag, auto
-from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union, Literal
 
 from pydantic import AliasChoices, BaseModel, Field, computed_field, field_validator
 
@@ -27,6 +27,11 @@ class Colormap(BaseModel):
     name: str = Field(description="Name of colormap, e.g. 'flare', 'heating'.")
     nodata_index: Optional[int] = Field(0, description="Index used for no data.")
     units: str = Field(description="Units, e.g. 'degree days', 'metres'.")
+    scaling: Literal["linear", "log"] = Field(
+        "linear",
+        description="Value-to-colour scaling: 'linear' (default) or 'log'. "
+        "'log' requires min_value > 0.",
+    )
 
 
 class MapInfo(BaseModel):

--- a/src/physrisk/api/v1/hazard_image.py
+++ b/src/physrisk/api/v1/hazard_image.py
@@ -1,4 +1,4 @@
-from typing import Any, List, NamedTuple, Optional
+from typing import Any, List, Literal, NamedTuple, Optional
 
 from pydantic import BaseModel, Field
 
@@ -54,6 +54,11 @@ class HazardImageRequest(BaseHazardRequest):
     tile: Optional[Tile]
     index_value: Optional[Any] = Field(
         None, description="(Non-spatial) index of the array to view."
+    )
+    scaling: Literal["linear", "log"] | None = Field(
+        None,
+        description="Value-to-colour scaling: 'linear' or 'log'. "
+        "'log' requires min_value > 0.",
     )
 
 

--- a/src/physrisk/data/image_creator.py
+++ b/src/physrisk/data/image_creator.py
@@ -48,6 +48,7 @@ class ImageCreator(HazardImageCreator):
         min_value: Optional[float] = None,
         max_value: Optional[float] = None,
         index_value: Optional[Union[str, float]] = None,
+        scaling: str = "linear",
     ):
         try:
             scenario_paths = self.source_paths.scenario_paths_for_id(
@@ -76,6 +77,7 @@ class ImageCreator(HazardImageCreator):
                 index_value=index_value,
                 min_value=min_value,
                 max_value=max_value,
+                scaling=scaling,
             )
         except Exception as e:
             # if we are creating a whole image that does not exist, we log the error
@@ -201,6 +203,7 @@ class ImageCreator(HazardImageCreator):
         index_value: Optional[Union[str, float, int]] = None,
         min_value: Optional[float] = None,
         max_value: Optional[float] = None,
+        scaling: str = "linear",
     ) -> Image.Image:
         """Get image for path specified as array of bytes."""
 
@@ -252,7 +255,9 @@ class ImageCreator(HazardImageCreator):
         def get_colors(index: int):
             return map_defn[str(index)]
 
-        rgba = self.to_rgba(data, get_colors, min_value=min_value, max_value=max_value)
+        rgba = self.to_rgba(
+            data, get_colors, min_value=min_value, max_value=max_value, scaling=scaling
+        )
         image = Image.fromarray(rgba, mode="RGBA")
         return image
 
@@ -266,6 +271,7 @@ class ImageCreator(HazardImageCreator):
         nodata_upper: Optional[float] = None,
         nodata_bin_transparent: bool = False,
         min_bin_transparent: bool = False,
+        scaling: str = "linear",
     ) -> np.ndarray:
         """Convert the data to an RGBA image using values provided by get_colors.
         We are particular about min and max values, ensuring that these get their own indices
@@ -275,6 +281,9 @@ class ImageCreator(HazardImageCreator):
         2: min_value < value < (max_value - min_value) / 253
         254: (max_value - min_value) / 253 <= value < max_value
         255 is >= max_value
+        With scaling='log' the in-between indices are assigned logarithmically
+        between min_value (which must be > 0) and max_value; the bin rules above
+        are unchanged.
 
         Args:
             data (np.ndarray): Two dimensional array.
@@ -285,6 +294,8 @@ class ImageCreator(HazardImageCreator):
             nodata_upper (Optional[float], optional): If supplied, values larger than or equal to nodata_upper threshold are considered nodata. Defaults to None.
             nodata_bin_transparent (bool, optional): If True make no_data bin transparent. Defaults to False.
             min_bin_transparent (bool, optional): If True make min_bin transparent. Defaults to False.
+            scaling (str): Value-to-colour scaling, 'linear' or 'log'.
+                'log' requires min_value > 0. Defaults to 'linear'.
 
         Returns:
             np.ndarray: RGBA array.
@@ -318,9 +329,22 @@ class ImageCreator(HazardImageCreator):
         mask_ge_max = data >= max_value
         mask_le_min = data <= min_value
 
-        np.add(data, -min_value, out=data)
-        np.multiply(data, 253.0 / (max_value - min_value), out=data)
-        np.add(data, 2.0, out=data)  # np.clip seems a bit slow so we do not use
+        if scaling == "log":
+            if min_value <= 0.0:
+                raise ValueError("scaling='log' requires a min_value greater than 0.")
+            # values <= min_value produce nan/-inf here; they are overwritten
+            # below via mask_le_min (and mask_nodata), as in the linear case
+            with np.errstate(divide="ignore", invalid="ignore"):
+                np.log(data, out=data)
+            np.add(data, -np.log(min_value), out=data)
+            np.multiply(data, 253.0 / (np.log(max_value) - np.log(min_value)), out=data)
+            np.add(data, 2.0, out=data)
+        elif scaling == "linear":
+            np.add(data, -min_value, out=data)
+            np.multiply(data, 253.0 / (max_value - min_value), out=data)
+            np.add(data, 2.0, out=data)  # np.clip seems a bit slow so we do not use
+        else:
+            raise ValueError(f"unsupported scaling: {scaling}")
 
         result = data.astype(np.uint8, casting="unsafe", copy=False)
         del data

--- a/src/physrisk/hazard_models/jba_image_creator.py
+++ b/src/physrisk/hazard_models/jba_image_creator.py
@@ -142,6 +142,7 @@ class JBAImageCreator(HazardImageCreator):
         min_value: Optional[float] = None,
         max_value: Optional[float] = None,
         index_value: Optional[Union[str, float]] = None,
+        scaling: str = "linear",
     ):
         assert tile is not None
 
@@ -177,7 +178,7 @@ class JBAImageCreator(HazardImageCreator):
             return map_defn[str(index)]
 
         rgba = ImageCreator.to_rgba(
-            depth, get_colors, min_value=min_value, max_value=max_value
+            depth, get_colors, min_value=min_value, max_value=max_value, scaling=scaling
         )
         image = Image.fromarray(rgba, mode="RGBA")
 
@@ -370,6 +371,7 @@ class CombinedImageCreator(HazardImageCreator):
         min_value: Optional[float] = None,
         max_value: Optional[float] = None,
         index_value: Optional[Union[str, float]] = None,
+        scaling: str = "linear",
     ):
         return self._creator(resource_id).create_image(
             resource_id,
@@ -381,6 +383,7 @@ class CombinedImageCreator(HazardImageCreator):
             min_value=min_value,
             max_value=max_value,
             index_value=index_value,
+            scaling=scaling,
         )
 
     def get_info(self, resource_id: str, scenario: str, year: int):

--- a/src/physrisk/kernel/hazard_model.py
+++ b/src/physrisk/kernel/hazard_model.py
@@ -248,6 +248,7 @@ class HazardImageCreator(Protocol):
         min_value: Optional[float] = None,
         max_value: Optional[float] = None,
         index_value: Optional[Union[str, float]] = None,
+        scaling: str = "linear",
     ):
         """Creates an image Tile for display on maps.
 
@@ -261,6 +262,8 @@ class HazardImageCreator(Protocol):
             min_value (Optional[float], optional): Value of colormap minimum. Defaults to None.
             max_value (Optional[float], optional): Value of colormap maximum. Defaults to None.
             index_value (Optional[str | float], optional): Value of the non-spatial 'index' dimension. Defaults to None.
+            scaling (str): Value-to-colour scaling, 'linear' or 'log'.
+                'log' requires min_value > 0. Defaults to 'linear'.
         """
         ...
 

--- a/src/physrisk/requests.py
+++ b/src/physrisk/requests.py
@@ -327,6 +327,15 @@ class Requester:
             if request.colormap is not None
             else (model.map.colormap.name if model.map.colormap is not None else "None")
         )
+        scaling = (
+            request.scaling
+            if request.scaling is not None
+            else (
+                model.map.colormap.scaling
+                if model.map.colormap is not None
+                else "linear"
+            )
+        )
         creator: HazardImageCreator = self.hazard_model_factory.image_creator()
         return creator.create_image(
             request.resource,
@@ -341,6 +350,7 @@ class Requester:
             min_value=request.min_value,
             max_value=request.max_value,
             index_value=request.index_value,
+            scaling=scaling,
         )
 
     def get_image_info(self, request: HazardImageInfoRequest):

--- a/tests/kernel/test_image_creation.py
+++ b/tests/kernel/test_image_creation.py
@@ -75,6 +75,40 @@ def test_image_creation(mock_inventory):
     np.testing.assert_equal(result, expected.astype(np.uint8))
 
 
+def test_image_creation_log_scaling():
+    colormap = colormap_provider.colormap("test")
+
+    def get_colors(index: int):
+        return colormap[str(index)]
+
+    im = np.array([[0.3, 0.1], [0.01, 0.005]])
+    result = ImageCreator.to_rgba(
+        im.copy(), get_colors, min_value=0.01, max_value=0.3, scaling="log"
+    )
+    # 0.3 >= max -> 255; 0.01 and 0.005 <= min -> 1;
+    # 0.1 -> 2 + 253 * log(0.1 / 0.01) / log(0.3 / 0.01)
+    expected = np.array(
+        [
+            [255, 2 + 253 * np.log(0.1 / 0.01) / np.log(0.3 / 0.01)],
+            [1, 1],
+        ]
+    )
+    np.testing.assert_equal(result, expected.astype(np.uint8))
+
+
+def test_log_scaling_requires_positive_min():
+    colormap = colormap_provider.colormap("test")
+
+    def get_colors(index: int):
+        return colormap[str(index)]
+
+    im = np.array([[0.3, 0.1], [0.01, 0.005]])
+    with pytest.raises(ValueError):
+        ImageCreator.to_rgba(
+            im.copy(), get_colors, min_value=0.0, max_value=0.3, scaling="log"
+        )
+
+
 @pytest.fixture
 def mock_inventory():
     return Inventory(


### PR DESCRIPTION
HazardImageRequest gains an optional scaling field ('linear'/'log'). ImageCreator.to_rgba maps values logarithmically between min_value (must be > 0, acts as the floor) and max_value when scaling='log'; bin rules (nodata/min/max indices) are unchanged.

Co-authored-by: Carlos San Millán [csanmillan@arfimaconsulting.com](mailto:csanmillan@arfimaconsulting.com)
Signed-off-by: Juan Román Roche [jroman@arfimaconsulting.com](mailto:jroman@arfimaconsulting.com)