### PR TITLE
Make mapping of unknown occupancy code to Hazus curves optional

### DIFF
--- a/src/physrisk/api/v1/impact_req_resp.py
+++ b/src/physrisk/api/v1/impact_req_resp.py
@@ -29,6 +29,11 @@ class CalcSettings(BaseModel):
         default=None,
         description="Dictionary of hazards and corresponding indicator ids to include in analysis.",
     )
+    map_unknown_occ: bool = Field(
+        default=True,
+        description="If True, map unknown occupancy codes to an average of Hazus vulnerability curves."
+        "Only acts if the requester is configured to use Hazus vulerability curves.",
+    )
 
 
 class AssetMeasuresSpecification(BaseModel):

--- a/src/physrisk/api/v1/impact_req_resp.py
+++ b/src/physrisk/api/v1/impact_req_resp.py
@@ -30,7 +30,7 @@ class CalcSettings(BaseModel):
         description="Dictionary of hazards and corresponding indicator ids to include in analysis.",
     )
     map_unknown_occ: bool = Field(
-        default=True,
+        default=False,
         description="If True, map unknown occupancy codes to an average of Hazus vulnerability curves."
         "Only acts if the requester is configured to use Hazus vulerability curves.",
     )

--- a/src/physrisk/api/v1/impact_req_resp.py
+++ b/src/physrisk/api/v1/impact_req_resp.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, NamedTuple, Optional, Sequence
+from typing import Any, Dict, List, NamedTuple, Optional, Sequence, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -29,10 +29,14 @@ class CalcSettings(BaseModel):
         default=None,
         description="Dictionary of hazards and corresponding indicator ids to include in analysis.",
     )
-    map_unknown_occ: bool = Field(
-        default=False,
-        description="If True, map unknown occupancy codes to an average of Hazus vulnerability curves."
-        "Only acts if the requester is configured to use Hazus vulerability curves.",
+    vulnerability_curve_mapping: Literal["hazus", "hazus_no_unknown", "config_only"] = (
+        Field(
+            "hazus_no_unknown",
+            description="Configuration for the vulnerability models."
+            "hazus: use hazus curves, for the unknown occupancy code, use an average of hazus curves."
+            "hazus_no_unknown: use hazus curves, for the unknown occupancy code, fallback to config based curves."
+            "config_only: do not use hazus curves.",
+        )
     )
 
 

--- a/src/physrisk/container.py
+++ b/src/physrisk/container.py
@@ -103,6 +103,7 @@ class DictBasedVulnerabilityModelsFactory(PVulnerabilityModelsFactory):
     def vulnerability_models(
         self,
         hazard_scope: dict[type[Hazard], set[str] | None] | None = None,
+        use_oed_hazus_curves: bool = False,
         map_unknown_occ: bool = False,
     ) -> PVulnerabilityModels:
         return DictBasedVulnerabilityModels(
@@ -114,14 +115,13 @@ class DefaultVulnerabilityModelsFactory(VulnerabilityModelsFactory):
     """Default vulnerability approach. 'default_vulnerability_models'
     programmatic models are used, to which FEMA Hazus vulnerability-based
     models are added and finally configuration.
-    FEMA Hazus vulnerability-based models excluded by default (until non-experimental).
+    FEMA Hazus vulnerability-based models use is toggled at runtime.
     """
 
-    def __init__(self, use_oed_hazus_curves: bool = True):
+    def __init__(self):
         super().__init__(
             config=VulnerabilityModelsFactory.embedded_vulnerability_config(),
             programmatic_models=calc.default_vulnerability_models(),
-            use_oed_hazus_curves=use_oed_hazus_curves,
             standard_of_protection=StandardOfProtection.CONSTANT_DEPTH,
         )
 

--- a/src/physrisk/container.py
+++ b/src/physrisk/container.py
@@ -103,7 +103,7 @@ class DictBasedVulnerabilityModelsFactory(PVulnerabilityModelsFactory):
     def vulnerability_models(
         self,
         hazard_scope: dict[type[Hazard], set[str] | None] | None = None,
-        map_unknown_occ: bool = True,
+        map_unknown_occ: bool = False,
     ) -> PVulnerabilityModels:
         return DictBasedVulnerabilityModels(
             calc.alternate_default_vulnerability_models_scores()

--- a/src/physrisk/container.py
+++ b/src/physrisk/container.py
@@ -101,14 +101,16 @@ class DefaultHazardModelFactory(HazardModelFactory):
 
 class DictBasedVulnerabilityModelsFactory(PVulnerabilityModelsFactory):
     def vulnerability_models(
-        self, hazard_scope: dict[type[Hazard], set[str] | None] | None = None
+        self,
+        hazard_scope: dict[type[Hazard], set[str] | None] | None = None,
+        map_unknown_occ: bool = True,
     ) -> PVulnerabilityModels:
         return DictBasedVulnerabilityModels(
             calc.alternate_default_vulnerability_models_scores()
         )
 
 
-class DefaultVulnerabilityModelFactory(VulnerabilityModelsFactory):
+class DefaultVulnerabilityModelsFactory(VulnerabilityModelsFactory):
     """Default vulnerability approach. 'default_vulnerability_models'
     programmatic models are used, to which FEMA Hazus vulnerability-based
     models are added and finally configuration.
@@ -168,7 +170,7 @@ class Container(containers.DeclarativeContainer):
 
     measures_factory = providers.Factory(calc.DefaultMeasuresFactory)
 
-    vulnerability_models_factory = providers.Factory(DefaultVulnerabilityModelFactory)
+    vulnerability_models_factory = providers.Factory(DefaultVulnerabilityModelsFactory)
 
     requester = providers.Singleton(
         Requester,

--- a/src/physrisk/kernel/vulnerability_model.py
+++ b/src/physrisk/kernel/vulnerability_model.py
@@ -139,6 +139,7 @@ class VulnerabilityModelsFactory(Protocol):
     def vulnerability_models(
         self,
         hazard_scope: dict[type[Hazard], set[str] | None] | None = ...,
+        use_oed_hazus_curves: bool = ...,
         map_unknown_occ: bool = ...,
     ) -> VulnerabilityModels:
         """Create a VulnerabilityModels instance, that can based on a number of options.

--- a/src/physrisk/kernel/vulnerability_model.py
+++ b/src/physrisk/kernel/vulnerability_model.py
@@ -137,7 +137,9 @@ class VulnerabilityModels(Protocol):
 
 class VulnerabilityModelsFactory(Protocol):
     def vulnerability_models(
-        self, hazard_scope: dict[type[Hazard], set[str] | None] | None = None
+        self,
+        hazard_scope: dict[type[Hazard], set[str] | None] | None = ...,
+        map_unknown_occ: bool = ...,
     ) -> VulnerabilityModels:
         """Create a VulnerabilityModels instance, that can based on a number of options.
 

--- a/src/physrisk/requests.py
+++ b/src/physrisk/requests.py
@@ -290,9 +290,25 @@ class Requester:
                 for h, inds in request.calc_settings.hazard_scope_by_indicator.items()
             }
 
+        match request.calc_settings.vulnerability_curve_mapping:
+            case "hazus":
+                use_oed_hazus_curves = True
+                map_unknown_occ = True
+            case "hazus_no_unknown":
+                use_oed_hazus_curves = True
+                map_unknown_occ = False
+            case "config_only":
+                use_oed_hazus_curves = False
+                map_unknown_occ = False
+            case _:
+                raise ValueError(
+                    f"Unsupported value for `vulnerability_curve_mapping`: {request.calc_settings.vulnerability_curve_mapping}."
+                )
+
         vulnerability_models = self.vulnerability_models_factory.vulnerability_models(
             hazard_scope=hazard_scope,
-            map_unknown_occ=request.calc_settings.map_unknown_occ,
+            use_oed_hazus_curves=use_oed_hazus_curves,
+            map_unknown_occ=map_unknown_occ,
         )
         asset_measure_calculators = self.measures_factory.asset_calculators(
             request.use_case_id

--- a/src/physrisk/requests.py
+++ b/src/physrisk/requests.py
@@ -291,7 +291,8 @@ class Requester:
             }
 
         vulnerability_models = self.vulnerability_models_factory.vulnerability_models(
-            hazard_scope=hazard_scope
+            hazard_scope=hazard_scope,
+            map_unknown_occ=request.calc_settings.map_unknown_occ,
         )
         asset_measure_calculators = self.measures_factory.asset_calculators(
             request.use_case_id

--- a/src/physrisk/vulnerability_models/impact_function_selector.py
+++ b/src/physrisk/vulnerability_models/impact_function_selector.py
@@ -3,6 +3,7 @@
 import collections
 from dataclasses import dataclass
 from importlib import import_module
+import copy
 
 from importlib.resources import files
 from typing import NamedTuple, Protocol, Sequence
@@ -304,6 +305,8 @@ class OEDHazusImpactFunctionSelector(ImpactFunctionSelector):
         )
         self.vulnerability_config_items = config_items
 
+        self._map_unknown_occ = True
+
     def select(
         self,
         asset: Asset,
@@ -339,9 +342,25 @@ class OEDHazusImpactFunctionSelector(ImpactFunctionSelector):
             raise TypeError(
                 f"OED-Hazus mapping only supports assets of type 'Asset', got '{type(asset)}'"
             )
+        if (
+            not self.map_unknown_occ
+            and asset.occupancy_code == _UNKNOWN_SENTINELS["occupancy_code"]
+        ):
+            return None
         impact_function, _ = self.oed_mapper.map(asset, hazard_type)
         # consider logging the explanation (/ exposing via service)
         return impact_function
+
+    @property
+    def map_unknown_occ(self) -> bool:
+        return self._map_unknown_occ
+
+    def with_runtime_options(self, *, map_unknown_occ: bool):
+        """Return a new selector with the given runtime options."""
+        # shallow copy, so that the underlying OEDHazusMapper is shared
+        clone = copy.copy(self)
+        clone._map_unknown_occ = map_unknown_occ
+        return clone
 
 
 class CombinedImpactFunctionSelector(ImpactFunctionSelector):

--- a/src/physrisk/vulnerability_models/impact_function_selector.py
+++ b/src/physrisk/vulnerability_models/impact_function_selector.py
@@ -305,7 +305,7 @@ class OEDHazusImpactFunctionSelector(ImpactFunctionSelector):
         )
         self.vulnerability_config_items = config_items
 
-        self._map_unknown_occ = True
+        self._map_unknown_occ = False
 
     def select(
         self,

--- a/src/physrisk/vulnerability_models/vulnerability.py
+++ b/src/physrisk/vulnerability_models/vulnerability.py
@@ -54,19 +54,18 @@ class VulnerabilityModelsFactory(PVulnerabilityModelsFactory):
         self,
         config: Sequence[VulnerabilityConfigItem] = [],
         programmatic_models: dict[type[Asset], list[VulnerabilityModelBase]] = {},
-        use_oed_hazus_curves: bool = False,
         standard_of_protection: StandardOfProtection = StandardOfProtection.CONSTANT_DEPTH,
     ):  # default_vulnerability_models):
         self.config_items = config
         self.oed_hazus_selector = OEDHazusImpactFunctionSelector(config)
         self.config_based_selector = ConfigBasedImpactFunctionSelector(config)
         self.programmatic_models = programmatic_models
-        self.use_oed_hazus_curves = use_oed_hazus_curves
         self.standard_of_protection = standard_of_protection
 
     def vulnerability_models(
         self,
         hazard_scope: dict[type[Hazard], set[str] | None] | None = None,
+        use_oed_hazus_curves: bool = True,
         map_unknown_occ: bool = False,
         disable_api_calls=False,
     ) -> PVulnerabilityModels:
@@ -83,7 +82,7 @@ class VulnerabilityModelsFactory(PVulnerabilityModelsFactory):
             programmatic_models=self.programmatic_models,
             hazard_scope=hazard_scope,
             disable_api_calls=disable_api_calls,
-            use_oed_hazus_curves=self.use_oed_hazus_curves,
+            use_oed_hazus_curves=use_oed_hazus_curves,
             standard_of_protection=self.standard_of_protection,
         )
 

--- a/src/physrisk/vulnerability_models/vulnerability.py
+++ b/src/physrisk/vulnerability_models/vulnerability.py
@@ -58,11 +58,8 @@ class VulnerabilityModelsFactory(PVulnerabilityModelsFactory):
         standard_of_protection: StandardOfProtection = StandardOfProtection.CONSTANT_DEPTH,
     ):  # default_vulnerability_models):
         self.config_items = config
-        oed_hazus_selector = OEDHazusImpactFunctionSelector(config)
+        self.oed_hazus_selector = OEDHazusImpactFunctionSelector(config)
         self.config_based_selector = ConfigBasedImpactFunctionSelector(config)
-        self.combined_selector = CombinedImpactFunctionSelector(
-            oed_hazus_selector, self.config_based_selector
-        )
         self.programmatic_models = programmatic_models
         self.use_oed_hazus_curves = use_oed_hazus_curves
         self.standard_of_protection = standard_of_protection
@@ -70,11 +67,19 @@ class VulnerabilityModelsFactory(PVulnerabilityModelsFactory):
     def vulnerability_models(
         self,
         hazard_scope: dict[type[Hazard], set[str] | None] | None = None,
+        map_unknown_occ: bool = True,
         disable_api_calls=False,
     ) -> PVulnerabilityModels:
+        oed_hazus_selector = self.oed_hazus_selector.with_runtime_options(
+            map_unknown_occ=map_unknown_occ
+        )
+        combined_selector = CombinedImpactFunctionSelector(
+            oed_hazus_selector, self.config_based_selector
+        )
+
         return VulnerabilityModels(
             config_based_selector=self.config_based_selector,
-            combined_selector=self.combined_selector,
+            combined_selector=combined_selector,
             programmatic_models=self.programmatic_models,
             hazard_scope=hazard_scope,
             disable_api_calls=disable_api_calls,
@@ -123,7 +128,7 @@ class VulnerabilityModels(PVulnerabilityModels):
 
         self.hazard_scope = hazard_scope
         self.disable_api_calls = disable_api_calls
-        self.stanard_of_protection = standard_of_protection
+        self.standard_of_protection = standard_of_protection
 
         all_models: dict[VulnModelKey, VulnerabilityModelBase] = {}
 
@@ -141,7 +146,7 @@ class VulnerabilityModels(PVulnerabilityModels):
 
         # add config based models
         config_based_models_dict = VulnerabilityModels.config_based_models(
-            config_based_selector, self.stanard_of_protection
+            config_based_selector, self.standard_of_protection
         )
         for k, v in config_based_models_dict.items():
             if k not in all_models:

--- a/src/physrisk/vulnerability_models/vulnerability.py
+++ b/src/physrisk/vulnerability_models/vulnerability.py
@@ -67,7 +67,7 @@ class VulnerabilityModelsFactory(PVulnerabilityModelsFactory):
     def vulnerability_models(
         self,
         hazard_scope: dict[type[Hazard], set[str] | None] | None = None,
-        map_unknown_occ: bool = True,
+        map_unknown_occ: bool = False,
         disable_api_calls=False,
     ) -> PVulnerabilityModels:
         oed_hazus_selector = self.oed_hazus_selector.with_runtime_options(

--- a/tests/risk_models/test_portfolio_models.py
+++ b/tests/risk_models/test_portfolio_models.py
@@ -162,7 +162,6 @@ def test_impact_aggregation_end_to_end():
     container.override_providers(
         vulnerability_models_factory=providers.Factory(
             VulnerabilityModelsFactory,
-            use_oed_hazus_curves=True,
             config=VulnerabilityModelsFactory.embedded_vulnerability_config(),
         )
     )
@@ -396,7 +395,6 @@ def test_impact_aggregation_end_to_end_multi_hazard():
     container.override_providers(
         vulnerability_models_factory=providers.Factory(
             VulnerabilityModelsFactory,
-            use_oed_hazus_curves=True,
             config=VulnerabilityModelsFactory.embedded_vulnerability_config(),
         )
     )
@@ -422,7 +420,8 @@ def test_impact_aggregation_end_to_end_multi_hazard():
         include_calc_details=False,
         use_case_id="company",
         calc_settings=CalcSettings(
-            hazard_scope="RiverineInundation,Wind,Fire,ChronicHeat"
+            hazard_scope="RiverineInundation,Wind,Fire,ChronicHeat",
+            vulnerability_curve_mapping="hazus",
         ),
         measures_specification=AssetMeasuresSpecification(
             measure_ids=["mean"],

--- a/tests/risk_models/test_risk_models.py
+++ b/tests/risk_models/test_risk_models.py
@@ -527,6 +527,7 @@ def test_generic_model_via_requests_default_vulnerability():
         "include_calc_details": True,
         "years": years,
         "scenarios": scenarios,
+        "calc_settings": {"map_unknown_occ": True},
     }
 
     container = Container()
@@ -724,7 +725,7 @@ def test_generic_model_via_requests_custom():
         def vulnerability_models(
             self,
             hazard_scope: dict[type[Hazard], set[str] | None] | None = None,
-            map_unknown_occ: bool = True,
+            map_unknown_occ: bool = False,
         ) -> VulnerabilityModels:
             return _vulnerability_models()
 

--- a/tests/risk_models/test_risk_models.py
+++ b/tests/risk_models/test_risk_models.py
@@ -722,7 +722,9 @@ def test_generic_model_via_requests_custom():
 
     class TestVulnerabilityModelsFactory(PVulnerabilityModelsFactory):
         def vulnerability_models(
-            self, hazard_scope: dict[type[Hazard], set[str] | None] | None = None
+            self,
+            hazard_scope: dict[type[Hazard], set[str] | None] | None = None,
+            map_unknown_occ: bool = True,
         ) -> VulnerabilityModels:
             return _vulnerability_models()
 

--- a/tests/risk_models/test_risk_models.py
+++ b/tests/risk_models/test_risk_models.py
@@ -527,7 +527,7 @@ def test_generic_model_via_requests_default_vulnerability():
         "include_calc_details": True,
         "years": years,
         "scenarios": scenarios,
-        "calc_settings": {"map_unknown_occ": True},
+        "calc_settings": {"vulnerability_curve_mapping": "hazus"},
     }
 
     container = Container()
@@ -725,6 +725,7 @@ def test_generic_model_via_requests_custom():
         def vulnerability_models(
             self,
             hazard_scope: dict[type[Hazard], set[str] | None] | None = None,
+            use_oed_hazus_curves: bool = False,
             map_unknown_occ: bool = False,
         ) -> VulnerabilityModels:
             return _vulnerability_models()

--- a/tests/vulnerability_models/test_config_based_vulnerability.py
+++ b/tests/vulnerability_models/test_config_based_vulnerability.py
@@ -1063,7 +1063,9 @@ def test_config_based_acute_model_with_sop():
         )
     ]
     factory = VulnerabilityModelsFactory(config=config_items)
-    vulnerability_models = factory.vulnerability_models(disable_api_calls=True)
+    vulnerability_models = factory.vulnerability_models(
+        disable_api_calls=True, use_oed_hazus_curves=False
+    )
     source_paths = CoreInventorySourcePaths(
         EmbeddedInventory(), CoreFloodModels.TUDelft
     )
@@ -1147,7 +1149,9 @@ def test_config_based_acute_model_with_uncertainty():
         )
     ]
     factory = VulnerabilityModelsFactory(config=config_items)
-    vulnerability_models = factory.vulnerability_models(disable_api_calls=True)
+    vulnerability_models = factory.vulnerability_models(
+        disable_api_calls=True, use_oed_hazus_curves=False
+    )
     source_paths = CoreInventorySourcePaths(
         EmbeddedInventory(), CoreFloodModels.TUDelft
     )
@@ -1299,7 +1303,8 @@ def test_combined_hazus_config_vulnerability_model():
         "years": [2050],
         "calc_settings": {
             # "hazard_interp": "linear",
-            "hazard_scope": "RiverineInundation"  # a useful way to select a subset of hazards
+            "hazard_scope": "RiverineInundation",  # a useful way to select a subset of hazards
+            "vulnerability_curve_mapping": "hazus",
         },
     }
     container = Container()
@@ -1312,7 +1317,7 @@ def test_combined_hazus_config_vulnerability_model():
     )
     container.override_providers(
         vulnerability_models_factory=providers.Factory(
-            VulnerabilityModelsFactory, config=config_items, use_oed_hazus_curves=True
+            VulnerabilityModelsFactory, config=config_items
         )
     )
     requester = container.requester()

--- a/tests/vulnerability_models/test_oed_based_config.py
+++ b/tests/vulnerability_models/test_oed_based_config.py
@@ -539,7 +539,9 @@ def test_combined_selector():
 
 def test_combine_curves():
     vulnerability_config = VulnerabilityModelsFactory.embedded_vulnerability_config()
-    oed_hazus_selector = OEDHazusImpactFunctionSelector(vulnerability_config)
+    oed_hazus_selector = OEDHazusImpactFunctionSelector(
+        vulnerability_config
+    ).with_runtime_options(map_unknown_occ=True)
     asset = OEDAsset(
         latitude=50.0,
         longitude=1.0,


### PR DESCRIPTION
I implement this as an optional runtime flag set by calling `OEDHazusImpactFunctionSelector.with_runtime_options(map_unknown_occ)` inside `VulnerabilityModelsFactory.vulnerability_models()`. The default behavior is to not map (False).

I also make the flag use_oed_hazus_curves runtime configurable by removing it from the `__init__` of the `VulnerabilityModelsFactory` and moving it to `VulnerabilityModelsFactory.vulnerability_models()`. The default is to use hazus curves (True).

To toggle these two options at runtime, I introduce a field vulnerability_curve_mapping in `CalcSettings` that takes literal values "hazus", "hazus_no_unknown" and "config_only". 
* hazus: sets use_oed_hazus_curves = True and map_unknown_occ = True
* hazus_no_unknown: sets use_oed_hazus_curves = True and map_unknown_occ = False
* config_only: sets use_oed_hazus_curves = False

The default is "hazus_no_unknown".