### PR TITLE
Make buffer scaled Web Mercator metres

### DIFF
--- a/src/physrisk/data/pregenerated_hazard_model.py
+++ b/src/physrisk/data/pregenerated_hazard_model.py
@@ -14,6 +14,8 @@ from physrisk.kernel.hazards import (
     Hail,
     Hazard,
     IndicatorData,
+    Landslide,
+    Subsidence,
     indicator_data,
 )
 
@@ -43,10 +45,32 @@ class PregeneratedHazardModel(HazardModel):
         hazard_data_providers: Dict[Type[Hazard], HazardDataProvider],
         interpolate_years: bool = False,
         zarr_max_workers: int = 32,
+        nan_is_zero: Optional[set[tuple[type[Hazard], str]]] = None,
+        nan_is_no_data: Optional[set[tuple[type[Hazard], str]]] = None,
     ):
+        """
+        Args:
+            hazard_data_providers: Map from hazard type to its data provider.
+            interpolate_years: Whether to interpolate hazard data between available years.
+            zarr_max_workers: Max threads for concurrent Zarr chunk reads.
+            nan_is_zero: (hazard_type, indicator_id) pairs where NaN is treated as 0. Defaults to common indicators (fire, drought, hail, subsidence, landslide).
+            nan_is_no_data: (hazard_type, indicator_id) pairs where NaN causes a failed response. Mutually exclusive with nan_is_zero.
+        """
         self.hazard_data_providers = hazard_data_providers
         self.interpolate_years = interpolate_years
         self.zarr_max_workers = zarr_max_workers
+        self._nan_is_zero: set[tuple[type[Hazard], str]] = (
+            nan_is_zero
+            if nan_is_zero is not None
+            else PregeneratedHazardModel._default_nan_is_zero()
+        )
+        self._nan_is_no_data: set[tuple[type[Hazard], str]] = (
+            nan_is_no_data if nan_is_no_data is not None else set()
+        )
+        if any(self._nan_is_zero & self._nan_is_no_data):
+            raise ValueError(
+                f"element {next(iter(self._nan_is_zero & self._nan_is_no_data))} appears in nan_is_zero and nan_is_no_data"
+            )
 
     def get_hazard_data(  # noqa: C901
         self, requests: Sequence[HazardDataRequest]
@@ -81,14 +105,8 @@ class PregeneratedHazardModel(HazardModel):
                 )
                 # for some indicators nan is taken to be 0 for purposes of calculation
                 # (nan might indicate the quantity cannot be calculated)
-                nan_is_zero = (
-                    (
-                        hazard_type == Drought
-                        and indicator_id == "months/spei3m/below/-2"
-                    )
-                    or (hazard_type == Hail and indicator_id == "days/above/5cm")
-                    or (hazard_type == Fire and indicator_id == "fire_probability")
-                )
+                nan_is_zero = (hazard_type, indicator_id) in self._nan_is_zero
+                nan_is_no_data = (hazard_type, indicator_id) in self._nan_is_no_data
                 # Add check that indicators are non-negative. This can occur in cases
                 # of extrapolation, even if underlying hazard data is well-behaved.
                 non_negative = nan_is_zero
@@ -175,6 +193,11 @@ class PregeneratedHazardModel(HazardModel):
                                     res.paths[index],
                                 )
                             else:
+                                if nan_is_no_data and np.any(np.isnan(values)):
+                                    responses[req] = HazardDataFailedResponse(
+                                        reason="unexpected nan"
+                                    )
+                                    continue
                                 if nan_is_zero:
                                     values[np.isnan(values)] = 0.0
                                 if non_negative:
@@ -244,6 +267,18 @@ class PregeneratedHazardModel(HazardModel):
             for v in values[0:5]:
                 logger.info(str(v[0]))
 
+    @staticmethod
+    def _default_nan_is_zero():
+        return set(
+            [
+                (Drought, "months/spei3m/below/-2"),
+                (Hail, "days/above/5cm"),
+                (Fire, "fire_probability"),
+                (Subsidence, "subsidence_probability"),
+                (Landslide, "landslide_probability"),
+            ]
+        )
+
 
 class ZarrHazardModel(PregeneratedHazardModel):
     def __init__(
@@ -255,7 +290,21 @@ class ZarrHazardModel(PregeneratedHazardModel):
         interpolation="floor",
         interpolate_years: bool = False,
         zarr_max_workers: int = 32,
+        nan_is_zero: Optional[set[tuple[type[Hazard], str]]] = None,
+        nan_is_no_data: Optional[set[tuple[type[Hazard], str]]] = None,
     ):
+        """Hazard model backed by Zarr arrays.
+
+        Args:
+            source_paths: Provides paths to Zarr arrays for each hazard type and indicator.
+            reader: Shared ZarrReader; created from store if not provided.
+            store: Zarr store (local, remote, or in-memory); used when reader is None.
+            interpolation: Spatial interpolation method ("floor" or "linear").
+            interpolate_years: Whether to interpolate hazard data between available years.
+            zarr_max_workers: Max threads for concurrent Zarr chunk reads.
+            nan_is_zero: (hazard_type, indicator_id) pairs where NaN is treated as 0. Defaults to common indicators (fire, drought, hail, subsidence, landslide).
+            nan_is_no_data: (hazard_type, indicator_id) pairs where NaN causes a failed response. Mutually exclusive with nan_is_zero.
+        """
         # share ZarrReaders across HazardDataProviders
         zarr_reader = ZarrReader(store=store) if reader is None else reader
         hazard_types = source_paths.hazard_types()
@@ -269,6 +318,8 @@ class ZarrHazardModel(PregeneratedHazardModel):
                 )
                 for t in hazard_types
             },
-            interpolate_years,
-            zarr_max_workers,
+            interpolate_years=interpolate_years,
+            zarr_max_workers=zarr_max_workers,
+            nan_is_zero=nan_is_zero,
+            nan_is_no_data=nan_is_no_data,
         )

--- a/src/physrisk/kernel/assets.py
+++ b/src/physrisk/kernel/assets.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
+import math
 from typing import Optional, Protocol, runtime_checkable
 
 from physrisk.kernel.hazards import (
@@ -154,6 +155,7 @@ class Asset:
     @staticmethod
     def buffered_geometry(geometry: BaseGeometry, buffer: float) -> BaseGeometry:
         """Relatively simple buffer, suitable for small buffers in metres around lat/lon points.
+        This
 
         Args:
             geometry (BaseGeometry): Geometry in EPSG:4326.
@@ -162,8 +164,28 @@ class Asset:
         Returns:
             BaseGeometry: Buffered geometry in EPSG:4326.
         """
+
+        """
+        # an an aside/future feature if needed
+        # this more accurate version uses a azimuthal equidistant projection
+        # and finding the UTM CRS is yet another possibility, e.g. via query_utm_crs_info
+        from pyproj import CRS
+        lat, lon = geometry.centroid.y, geometry.centroid.x
+        aeqd_crs = CRS.from_proj4(
+        f"+proj=aeqd +lat_0={lat} +lon_0={lon} +x_0=0 +y_0=0 +datum=WGS84 +units=m"
+    )
+        project_4326_to_aeqd = Transformer.from_crs("EPSG:4326", aeqd_crs, always_xy=True).transform
+        project_aeqd_to_4326 = Transformer.from_crs(aeqd_crs, "EPSG:4326", always_xy=True).transform
+        point_proj = transform(project_4326_to_aeqd, geometry)
+        buffered = point_proj.buffer(buffer)
+        return transform(project_aeqd_to_4326, buffered)
+        """
+        # buffer metres are interpreted to be scaled Web Mercator metres
+        # i.e. a point would appear as a (polygon approximation to) a circle on a Web Mercator map
+        # not an ellipse
         geom_proj: BaseGeometry = transform(project_4326_to_3857, geometry)
-        buffered = geom_proj.buffer(buffer, quad_segs=4)
+        scaling_factor = 1.0 / math.cos(math.radians(geometry.centroid.y))
+        buffered = geom_proj.buffer(buffer * scaling_factor, quad_segs=4)
         return transform(project_3857_to_4326, buffered)
 
 

--- a/src/physrisk/vulnerability_models/config_based_vuln_model_acute.py
+++ b/src/physrisk/vulnerability_models/config_based_vuln_model_acute.py
@@ -166,6 +166,12 @@ class ConfigBasedVulnerabilityModelAcute(VulnerabilityModelAcuteBase):
         if standard_of_protection > 0:
             assert isinstance(histo, HazardEventDataResponse)
             histo_intensities = histo.intensities
+            if not np.all(np.diff(histo_intensities) >= 0):
+                histo_intensities = np.maximum.accumulate(histo_intensities)
+                logging.warning(
+                    "Historical hazard curve is not monotonic; adjusting to ensure non-decreasing curve."
+                )
+                # can occur in case of API-based hazard models
             if conversion:
                 histo_intensities = ureg.convert(
                     histo_intensities, histo.units, curve.indicator_units

--- a/tests/kernel/test_assets.py
+++ b/tests/kernel/test_assets.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from shapely import Point
 from shapely.ops import transform
 

--- a/tests/kernel/test_assets.py
+++ b/tests/kernel/test_assets.py
@@ -1,0 +1,58 @@
+import numpy as np
+import pytest
+from shapely import Point
+from shapely.ops import transform
+
+from physrisk.kernel.assets import Asset, project_4326_to_3857
+
+
+def test_buffered_geometry_contains_origin():
+    """Buffered point contains the original point."""
+    pt = Point(10.0, 45.0)
+    buffered = Asset.buffered_geometry(pt, buffer=1000.0)
+    assert buffered.contains(pt)
+
+
+def test_buffered_geometry_approximate_size():
+    """Bounding box of the buffer in EPSG:3857 is approximately 2*buffer metres wide."""
+    buffer_m = 1000.0
+    pt = Point(0.0, 0.0)
+    buffered = Asset.buffered_geometry(pt, buffer_m)
+
+    buffered_3857 = transform(project_4326_to_3857, buffered)
+    minx, miny, maxx, maxy = buffered_3857.bounds
+    np.testing.assert_allclose(maxx - minx, 2 * buffer_m, rtol=0.01)
+    np.testing.assert_allclose(maxy - miny, 2 * buffer_m, rtol=0.01)
+
+
+def test_buffered_geometry_excludes_far_point():
+    """Point more than buffer_m away from origin is not contained."""
+    buffer_m = 1000.0
+    pt = Point(0.0, 0.0)
+    buffered = Asset.buffered_geometry(pt, buffer_m)
+    far = Point(0.0, 1.1 * buffer_m / 111319)  # ~1.1x buffer distance north
+    assert not buffered.contains(far)
+
+
+def test_asset_lat_lon_with_buffer():
+    """Asset with lat/lon and buffer has a polygon geometry; lat/lon are preserved."""
+    asset = Asset(id="a", latitude=51.5, longitude=-0.1, buffer=500.0)
+    assert asset.geometry is not None
+    assert asset.geometry.area > 0
+    assert asset.latitude == 51.5
+    assert asset.longitude == -0.1
+
+
+def test_asset_wkt_with_buffer():
+    """Asset with wkt_geometry and buffer has a buffered polygon; centroid matches the input point."""
+    asset = Asset(id="a", wkt_geometry="POINT (10.0 45.0)", buffer=200.0)
+    assert asset.geometry is not None
+    assert asset.geometry.area > 0
+    assert abs(asset.latitude - 45.0) < 0.01
+    assert abs(asset.longitude - 10.0) < 0.01
+
+
+def test_asset_no_buffer_has_no_geometry():
+    """Asset constructed from lat/lon without buffer has no geometry."""
+    asset = Asset(id="a", latitude=51.5, longitude=-0.1)
+    assert asset.geometry is None


### PR DESCRIPTION
- make buffer scaled Web Mercator metres;
- expose hazard indicator NaN options;
- extra protection for non-monotonic hazard data in acute model.